### PR TITLE
Feat: error handling refactor

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -69,7 +69,6 @@ export interface ICreateLinkParams {
 }
 export interface ICreateLinkResponse {
 	createdLink: ICreatedPeanutLink
-	status: SDKStatus
 }
 
 //createLinks
@@ -80,14 +79,6 @@ export interface ICreateLinksParams extends Omit<ICreateLinkParams, 'password'> 
 
 export interface ICreateLinksResponse {
 	createdLinks: ICreatedPeanutLink[]
-	status: SDKStatus
-}
-
-export enum ECreateLinksStatusCodes {
-	SUCCESS,
-	ERROR_PREPARING_TXs,
-	ERROR_SIGNING_AND_SUBMITTING_TX,
-	ERROR_GETTING_LINKS_FROM_TX,
 }
 
 //claimLinkGasless
@@ -100,7 +91,6 @@ export interface IClaimLinkGaslessParams {
 
 export interface IClaimLinkGaslessResponse {
 	txHash: string
-	status: SDKStatus
 }
 
 //ClaimLink
@@ -112,7 +102,6 @@ export interface IClaimLinkParams {
 
 export interface IClaimLinkResponse {
 	txHash: string
-	status: SDKStatus
 }
 
 //prepareCreatetxs
@@ -128,7 +117,6 @@ export interface IPrepareCreateTxsParams {
 
 export interface IPrepareCreateTxsResponse {
 	unsignedTxs: TransactionRequest[]
-	status: SDKStatus
 }
 
 //signAndSubmitTx
@@ -140,7 +128,6 @@ export interface ISignAndSubmitTxParams {
 export interface ISignAndSubmitTxResponse {
 	txHash: string
 	tx: ethers.providers.TransactionResponse
-	status: SDKStatus
 }
 
 //getLink
@@ -153,7 +140,6 @@ export interface IGetLinkFromTxParams {
 
 export interface IGetLinkFromTxResponse {
 	links: string[]
-	status: SDKStatus
 }
 
 //prepareClaimTx
@@ -161,7 +147,6 @@ export interface IPrepareClaimTxParams extends IClaimLinkParams {}
 
 export interface IPrepareClaimTxResponse {
 	unsignedTx: TransactionRequest
-	status: SDKStatus
 }
 
 //getLinkDetails
@@ -172,21 +157,17 @@ export interface IGetLinkDetailsParams {
 
 export interface IGetLinkDetailsResponse {
 	linkDetails: IPeanutLinkChainDetails
-	success: SDKStatus
 }
 
 //error object and enums
 
 export enum ECreateLinkStatusCodes {
-	SUCCESS,
-	ERROR_VALIDATING_LINK_DETAILS,
 	ERROR_PREPARING_TX,
 	ERROR_SIGNING_AND_SUBMITTING_TX,
 	ERROR_GETTING_LINKS_FROM_TX,
 }
 
 export enum EPrepareCreateTxsStatusCodes {
-	SUCCESS,
 	ERROR_VALIDATING_LINK_DETAILS,
 	ERROR_GETTING_DEFAULT_PROVIDER,
 	ERROR_GETTING_TX_COUNT,
@@ -199,17 +180,14 @@ export enum EPrepareCreateTxsStatusCodes {
 }
 
 export enum ESignAndSubmitTx {
-	SUCCESS,
 	ERROR_SENDING_TX,
 }
 
 export enum EGetLinkFromTxStatusCodes {
-	SUCCESS,
 	ERROR_GETTING_TX_RECEIPT_FROM_HASH,
 }
 
 export enum EClaimLinkStatusCodes {
-	SUCCESS,
 	ERROR,
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -602,14 +602,10 @@ async function prepareTxs({
 	try {
 		linkDetails = validateLinkDetails(linkDetails, passwords, numberOfLinks)
 	} catch (error) {
-		console.error(error)
-		return {
-			unsignedTxs: [],
-			status: new interfaces.SDKStatus(
-				interfaces.EPrepareCreateTxsStatusCodes.ERROR_VALIDATING_LINK_DETAILS,
-				'Error validating link details: please make sure all required fields are provided and valid'
-			),
-		}
+		throw new interfaces.SDKStatus(
+			interfaces.EPrepareCreateTxsStatusCodes.ERROR_VALIDATING_LINK_DETAILS,
+			'Error validating link details: please make sure all required fields are provided and valid'
+		)
 	}
 	const tokenAmountString = trim_decimal_overflow(linkDetails.tokenAmount, linkDetails.tokenDecimals!)
 	const tokenAmountBigNum = ethers.utils.parseUnits(tokenAmountString, linkDetails.tokenDecimals) // v5
@@ -621,14 +617,10 @@ async function prepareTxs({
 		try {
 			provider = await getDefaultProvider(String(linkDetails.chainId))
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_GETTING_DEFAULT_PROVIDER,
-					'Error getting the default provider'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_GETTING_DEFAULT_PROVIDER,
+				'Error getting the default provider'
+			)
 		}
 	}
 
@@ -668,14 +660,10 @@ async function prepareTxs({
 			approveTx && unsignedTxs.push(approveTx)
 			approveTx && config.verbose && console.log('approveTx:', approveTx)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC20_TX,
-					'Error preparing the approve ERC20 tx, please make sure you have enough balance and have approved the contract to spend your tokens'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC20_TX,
+				'Error preparing the approve ERC20 tx, please make sure you have enough balance and have approved the contract to spend your tokens'
+			)
 		}
 	} else if (linkDetails.tokenType == interfaces.EPeanutLinkType.erc721) {
 		config.verbose && console.log('checking ERC721 allowance...')
@@ -689,14 +677,10 @@ async function prepareTxs({
 
 			approveTx && unsignedTxs.push(approveTx)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC721_TX,
-					'Error preparing the approve ERC721 tx, please make sure you have approved the contract to spend your tokens'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC721_TX,
+				'Error preparing the approve ERC721 tx, please make sure you have approved the contract to spend your tokens'
+			)
 		}
 	} else if (linkDetails.tokenType == interfaces.EPeanutLinkType.erc1155) {
 		config.verbose && console.log('checking ERC1155 allowance...')
@@ -711,14 +695,10 @@ async function prepareTxs({
 
 			approveTx && unsignedTxs.push(approveTx)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC1155_TX,
-					'Error preparing the approve ERC1155 tx, please make sure you have approved the contract to spend your tokens'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_PREPARING_APPROVE_ERC1155_TX,
+				'Error preparing the approve ERC1155 tx, please make sure you have approved the contract to spend your tokens'
+			)
 		}
 	} else {
 		assert(false, 'Unsupported link type')
@@ -780,14 +760,10 @@ async function prepareTxs({
 		try {
 			depositTx = await contract.populateTransaction.makeDeposit(...depositParams, txOptions)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_MAKING_DEPOSIT,
-					'Error making the deposit to the contract'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_MAKING_DEPOSIT,
+				'Error making the deposit to the contract'
+			)
 		}
 	} else {
 		depositParams = [
@@ -821,14 +797,10 @@ async function prepareTxs({
 		try {
 			depositTx = await contract.populateTransaction.batchMakeDeposit(...depositParams, txOptions)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_MAKING_DEPOSIT,
-					'Error making the deposit to the contract'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_MAKING_DEPOSIT,
+				'Error making the deposit to the contract'
+			)
 		}
 	}
 
@@ -841,20 +813,16 @@ async function prepareTxs({
 		try {
 			nonce = await provider.getTransactionCount(address)
 		} catch (error) {
-			console.error(error)
-			return {
-				unsignedTxs: [],
-				status: new interfaces.SDKStatus(
-					interfaces.EPrepareCreateTxsStatusCodes.ERROR_GETTING_TX_COUNT,
-					'Error getting the transaction count'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_GETTING_TX_COUNT,
+				'Error getting the transaction count'
+			)
 		}
 
 		unsignedTxs.forEach((tx, i) => (tx.nonce = nonce + i))
 	}
 
-	return { status: new interfaces.SDKStatus(interfaces.EPrepareCreateTxsStatusCodes.SUCCESS), unsignedTxs }
+	return { unsignedTxs }
 }
 
 async function signAndSubmitTx({
@@ -877,16 +845,14 @@ async function signAndSubmitTx({
 	try {
 		tx = await structSigner.signer.sendTransaction(unsignedTx)
 	} catch (error) {
-		console.error(error)
-		return {
-			txHash: '',
-			tx: null,
-			status: new interfaces.SDKStatus(interfaces.ESignAndSubmitTx.ERROR_SENDING_TX, 'Error sending the Tx'),
-		}
+		throw new interfaces.SDKStatus(
+			interfaces.ESignAndSubmitTx.ERROR_SENDING_TX,
+			'Error sending the Tx: ' + error.message
+		)
 	}
 
 	config.verbose && console.log('tx: ', tx)
-	return { txHash: tx.hash, tx, status: new interfaces.SDKStatus(interfaces.ESignAndSubmitTx.SUCCESS) }
+	return { txHash: tx.hash, tx }
 }
 
 // async function signAndSubmitTx({
@@ -919,14 +885,10 @@ async function getLinksFromTx({
 	try {
 		txReceipt = await getTxReceiptFromHash(txHash, linkDetails.chainId, provider)
 	} catch (error) {
-		console.error(error)
-		return {
-			links: [],
-			status: new interfaces.SDKStatus(
-				interfaces.EGetLinkFromTxStatusCodes.ERROR_GETTING_TX_RECEIPT_FROM_HASH,
-				'Error getting the transaction receipt from the hash'
-			),
-		}
+		throw new interfaces.SDKStatus(
+			interfaces.EGetLinkFromTxStatusCodes.ERROR_GETTING_TX_RECEIPT_FROM_HASH,
+			'Error getting the transaction receipt from the hash'
+		)
 	}
 
 	// get deposit idx
@@ -951,7 +913,6 @@ async function getLinksFromTx({
 
 	return {
 		links: links,
-		status: new interfaces.SDKStatus(interfaces.EGetLinkFromTxStatusCodes.SUCCESS),
 	}
 }
 
@@ -1064,57 +1025,50 @@ async function createLink({
 	const provider = structSigner.signer.provider
 
 	// Prepare the transactions
-	const prepareTxsResponse = await prepareTxs({
-		address: await structSigner.signer.getAddress(),
-		linkDetails,
-		peanutContractVersion,
-		numberOfLinks: 1,
-		passwords: [password],
-		provider: provider,
-	})
-	if (prepareTxsResponse.status.code != interfaces.EPrepareCreateTxsStatusCodes.SUCCESS) {
-		return {
-			createdLink: { link: '', txHash: '' },
-			status: prepareTxsResponse.status,
-		}
+	let prepareTxsResponse
+	try {
+		prepareTxsResponse = await prepareTxs({
+			address: await structSigner.signer.getAddress(),
+			linkDetails,
+			peanutContractVersion,
+			numberOfLinks: 1,
+			passwords: [password],
+			provider: provider,
+		})
+	} catch (error) {
+		throw new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.ERROR_PREPARING_TX, error.message)
 	}
 
 	// Sign and submit the transactions sequentially
 	const signedTxs = []
 	for (const unsignedTx of prepareTxsResponse.unsignedTxs) {
-		const signedTx = await signAndSubmitTx({ structSigner, unsignedTx })
-		signedTxs.push(signedTx)
-		// wait for the transaction to be mined before sending the next one
-		// we could bundle both in one block, but only works if we set custom gas limits.
 		try {
+			const signedTx = await signAndSubmitTx({ structSigner, unsignedTx })
+			signedTxs.push(signedTx)
 			await signedTx.tx.wait()
 		} catch (error) {
-			console.error(error)
-			return {
-				createdLink: { link: '', txHash: '' },
-				status: new interfaces.SDKStatus(
-					interfaces.ESignAndSubmitTx.ERROR_SENDING_TX,
-					'Error waiting for the transaction'
-				),
-			}
+			throw new interfaces.SDKStatus(
+				interfaces.ECreateLinkStatusCodes.ERROR_SIGNING_AND_SUBMITTING_TX,
+				error.message
+			)
 		}
 	}
-	// await signedTxs[signedTxs.length - 1].tx.wait() // rpcs not fast enough
 
 	// Get the links from the transactions
-	const linksFromTxResp = await getLinksFromTx({
-		linkDetails,
-		txHash: signedTxs[signedTxs.length - 1].txHash,
-		passwords: [password],
-		provider: provider,
-	})
-
-	if (linksFromTxResp.status.code != interfaces.EGetLinkFromTxStatusCodes.SUCCESS) {
-		return { createdLink: { link: '', txHash: '' }, status: linksFromTxResp.status }
+	let linksFromTxResp
+	try {
+		linksFromTxResp = await getLinksFromTx({
+			linkDetails,
+			txHash: signedTxs[signedTxs.length - 1].txHash,
+			passwords: [password],
+			provider: provider,
+		})
+	} catch (error) {
+		throw new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.ERROR_GETTING_LINKS_FROM_TX, error.message)
 	}
+
 	return {
 		createdLink: { link: linksFromTxResp.links, txHash: signedTxs[signedTxs.length - 1].txHash },
-		status: new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.SUCCESS),
 	}
 }
 
@@ -1130,69 +1084,52 @@ async function createLinks({
 	const provider = structSigner.signer.provider
 
 	// Prepare the transactions
-	const prepareTxsResponse = await prepareTxs({
-		address: await structSigner.signer.getAddress(),
-		linkDetails,
-		peanutContractVersion,
-		numberOfLinks: numberOfLinks,
-		passwords: passwords,
-		provider: provider,
-	})
-	if (prepareTxsResponse.status.code != interfaces.EPrepareCreateTxsStatusCodes.SUCCESS) {
-		return {
-			createdLinks: [],
-			status: prepareTxsResponse.status,
-		}
+	let prepareTxsResponse
+	try {
+		prepareTxsResponse = await prepareTxs({
+			address: await structSigner.signer.getAddress(),
+			linkDetails,
+			peanutContractVersion,
+			numberOfLinks: numberOfLinks,
+			passwords: passwords,
+			provider: provider,
+		})
+	} catch (error) {
+		throw new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.ERROR_PREPARING_TX, error.message)
 	}
 
 	// Sign and submit the transactions
 	const signedTxs = []
 	for (const unsignedTx of prepareTxsResponse.unsignedTxs) {
-		const signedTx = await signAndSubmitTx({ structSigner, unsignedTx })
-		signedTxs.push(signedTx)
-		// wait for the transaction to be mined before sending the next one
-		// we could bundle both in one block, but only works if we set custom gas limits.
 		try {
+			const signedTx = await signAndSubmitTx({ structSigner, unsignedTx })
+			signedTxs.push(signedTx)
 			await signedTx.tx.wait()
 		} catch (error) {
-			console.error(error)
-			return {
-				createdLinks: [],
-				status: new interfaces.SDKStatus(
-					interfaces.ESignAndSubmitTx.ERROR_SENDING_TX,
-					'Error awaiting transaction'
-				),
-			}
-		}
-	}
-	// await signedTxs[signedTxs.length - 1].tx.wait()
-
-	if (signedTxs.some((tx) => tx.status.code !== peanut.interfaces.ESignAndSubmitTx.SUCCESS)) {
-		return {
-			createdLinks: [],
-			status: new interfaces.SDKStatus(
-				interfaces.ESignAndSubmitTx.ERROR_SENDING_TX,
-				'Error waiting for the transaction'
-			),
+			throw new interfaces.SDKStatus(
+				interfaces.ECreateLinkStatusCodes.ERROR_SIGNING_AND_SUBMITTING_TX,
+				error.message
+			)
 		}
 	}
 
 	config.verbose && console.log('signedTxs: ', signedTxs)
-
-	const linksFromTxResp = await getLinksFromTx({
-		linkDetails,
-		txHash: signedTxs[signedTxs.length - 1].txHash,
-		passwords: passwords,
-		provider,
-	})
-	if (linksFromTxResp.status.code != interfaces.EGetLinkFromTxStatusCodes.SUCCESS) {
-		return { createdLinks: [], status: linksFromTxResp.status }
+	let linksFromTxResp
+	try {
+		linksFromTxResp = await getLinksFromTx({
+			linkDetails,
+			txHash: signedTxs[signedTxs.length - 1].txHash,
+			passwords: passwords,
+			provider,
+		})
+	} catch (error) {
+		throw new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.ERROR_GETTING_LINKS_FROM_TX, error.message)
 	}
 	const createdLinks = linksFromTxResp.links.map((link) => {
 		return { link: link, txHash: signedTxs[signedTxs.length - 1].txHash }
 	})
 
-	return { createdLinks: createdLinks, status: new interfaces.SDKStatus(interfaces.ECreateLinkStatusCodes.SUCCESS) }
+	return { createdLinks: createdLinks }
 }
 
 /**
@@ -1259,7 +1196,6 @@ async function claimLink({
 	const txReceipt = await tx.wait()
 
 	return {
-		status: new interfaces.SDKStatus(interfaces.EClaimLinkStatusCodes.SUCCESS),
 		txHash: txReceipt.transactionHash,
 	}
 }


### PR DESCRIPTION
Changelog: 
- instead of returning an object that included an SDKStatus object when an error was caught, an error is being thrown now. 
- the return object of a function (e.g. prepareTxs) does not return an SDKStatus object anymore. The function will error out when an error is thrown, so no need to return a succes object when the function completes. 
- removed some unused enums/enum fields. 
