### PR TITLE
Painpoints fixes v1

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -31,7 +31,7 @@ export enum EPeanutLinkType {
 export interface IPeanutLinkDetails {
 	chainId: number
 	tokenAmount: number
-	tokenType: EPeanutLinkType
+	tokenType?: EPeanutLinkType
 	tokenAddress?: string
 	tokenId?: number
 	tokenDecimals?: number

--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -44,8 +44,11 @@ export interface ICreatedPeanutLink {
 	txHash: string
 }
 
-export interface IPeanutUnsignedTransactions {
-	unsignedTxs: TransactionRequest // change this any type to correct type
+export interface IPeanutUnsignedTransaction {
+	to: string
+	nonce: number
+	data: string
+	value: BigInt
 }
 
 export interface IReturnSuccessObject {
@@ -154,13 +157,13 @@ export interface IPrepareTxsParams {
 }
 
 export interface IPrepareTxsResponse {
-	unsignedTxs: TransactionRequest[]
+	unsignedTxs: IPeanutUnsignedTransaction[]
 }
 
 //signAndSubmitTx
 export interface ISignAndSubmitTxParams {
 	structSigner: IPeanutSigner
-	unsignedTx: TransactionRequest
+	unsignedTx: IPeanutUnsignedTransaction
 }
 
 export interface ISignAndSubmitTxResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -915,13 +915,13 @@ async function prepareTxs({
 
 	return {
 		unsignedTxs: unsignedTxs.map((unsignedTx) => {
-			const x: interfaces.IPeanutUnsignedTransaction = {
+			const tx: interfaces.IPeanutUnsignedTransaction = {
 				to: unsignedTx.to,
-				nonce: unsignedTx.nonce ? Number(unsignedTx.nonce) : undefined,
+				nonce: unsignedTx.nonce ? Number(unsignedTx.nonce) : null,
 				data: unsignedTx.data.toString(),
-				value: unsignedTx.value ? BigInt(unsignedTx.value.toString()) : undefined,
+				value: unsignedTx.value ? BigInt(unsignedTx.value.toString()) : null,
 			}
-			return x
+			return tx
 		}),
 	}
 }
@@ -931,7 +931,7 @@ async function signAndSubmitTx({
 	unsignedTx,
 }: interfaces.ISignAndSubmitTxParams): Promise<interfaces.ISignAndSubmitTxResponse> {
 	config.verbose && console.log('unsigned tx: ', unsignedTx)
-	const _unsignedTx = { ...unsignedTx, value: unsignedTx.value ? BigNumber.from(unsignedTx.value) : undefined }
+	const _unsignedTx = { ...unsignedTx, value: unsignedTx.value ? BigNumber.from(unsignedTx.value) : null }
 	// Set the transaction options using setFeeOptions
 	let txOptions
 	try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1866,7 +1866,7 @@ async function getContractType({
 }: {
 	provider: ethers.providers.Provider
 	address: string
-}): Promise<'NATIVE' | 'ERC20' | 'ERC721' | 'ERC1155'> {
+}): Promise<interfaces.EPeanutLinkType> {
 	const minimalABI = [
 		'function supportsInterface(bytes4) view returns (bool)',
 		'function totalSupply() view returns (uint256)',
@@ -1891,10 +1891,10 @@ async function getContractType({
 			.catch(() => false)
 	}
 
-	if (address.toLowerCase() === ethers.constants.AddressZero.toLowerCase()) return 'NATIVE'
-	if (isERC1155) return 'ERC1155'
-	if (isERC721) return 'ERC721'
-	if (isERC20) return 'ERC20'
+	if (address.toLowerCase() === ethers.constants.AddressZero.toLowerCase()) return 0
+	if (isERC20) return 1
+	if (isERC721) return 2
+	if (isERC1155) return 3
 }
 
 async function supportsInterface(contract, interfaceId) {
@@ -1911,7 +1911,7 @@ async function getContractDetails({
 }: {
 	address: string
 	provider: ethers.providers.Provider
-}): Promise<{ type: number; decimals?: number; name?: string; symbol?: string }> {
+}): Promise<{ type: interfaces.EPeanutLinkType; decimals?: number; name?: string; symbol?: string }> {
 	//get the contract type
 	const contractType = await getContractType({ address: address, provider: provider })
 	//@ts-ignore
@@ -1919,13 +1919,13 @@ async function getContractDetails({
 
 	config.verbose && console.log('contractType: ', contractType)
 	switch (contractType) {
-		case 'NATIVE': {
+		case 0: {
 			return {
 				type: 0,
 				decimals: 18,
 			}
 		}
-		case 'ERC20': {
+		case 1: {
 			const contract = new ethers.Contract(address, ERC20_ABI, batchprov)
 			const [name, symbol, decimals] = await Promise.all([
 				contract.name(),
@@ -1940,7 +1940,7 @@ async function getContractDetails({
 				decimals: decimals,
 			}
 		}
-		case 'ERC721': {
+		case 2: {
 			const contract = new ethers.Contract(address, ERC721_ABI, batchprov)
 			const [fetchedName, fetchedSymbol] = await Promise.all([contract.name(), contract.symbol()])
 			config.verbose && console.log('details: ', [fetchedName, fetchedSymbol])
@@ -1950,7 +1950,7 @@ async function getContractDetails({
 				symbol: fetchedSymbol,
 			}
 		}
-		case 'ERC1155': {
+		case 3: {
 			const contract = new ethers.Contract(address, ERC1155_ABI, batchprov)
 			const [fetchedName, fetchedSymbol] = await Promise.all([contract.name(), contract.symbol()])
 			config.verbose && console.log('details: ', [fetchedName, fetchedSymbol])

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,9 @@ async function fetchGetBalance(rpcUrl: string) {
 	return json
 }
 
+/**
+ * This function is used to get the default provider for a given chainId.
+ */
 async function getDefaultProvider(chainId: string): Promise<ethers.providers.JsonRpcProvider> {
 	config.verbose && console.log('Getting default provider for chainId ', chainId)
 	if (!CHAIN_DETAILS[chainId]) {
@@ -139,6 +142,9 @@ async function getDefaultProvider(chainId: string): Promise<ethers.providers.Jso
 	}
 }
 
+/**
+ * Like getDefaultProvider, but only returns a string with the RPC URL.
+ */
 async function getDefaultRpcUrl(chainId: string): Promise<string> {
 	const defaultProvider = await getDefaultProvider(chainId)
 	const rpcUrl = defaultProvider.connection.url

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,12 @@ async function getDefaultProvider(chainId: string): Promise<ethers.providers.Jso
 	}
 }
 
+async function getDefaultRpcUrl(chainId: string): Promise<string> {
+	const defaultProvider = await getDefaultProvider(chainId)
+	const rpcUrl = defaultProvider.connection.url
+	return rpcUrl
+}
+
 async function createValidProvider(rpcUrl: string): Promise<ethers.providers.JsonRpcProvider> {
 	try {
 		const provider = new ethers.providers.JsonRpcProvider({
@@ -2502,6 +2508,7 @@ const peanut = {
 	getAllUnclaimedDepositsWithIdxForAddress,
 	getContract,
 	getDefaultProvider,
+	getDefaultRpcUrl,
 	getDepositIdx,
 	getDepositIdxs,
 	getEIP1559Tip,
@@ -2573,6 +2580,7 @@ export {
 	getAllUnclaimedDepositsWithIdxForAddress,
 	getContract,
 	getDefaultProvider,
+	getDefaultRpcUrl,
 	getDepositIdx,
 	getDepositIdxs,
 	getEIP1559Tip,

--- a/test/basic/getContractDetails.test.ts
+++ b/test/basic/getContractDetails.test.ts
@@ -1,0 +1,22 @@
+import peanut, { interfaces } from '../../src/index' // import directly from source code
+import { ethers } from 'ethersv5' // v5
+import dotenv from 'dotenv'
+// import fetch from 'node-fetch'
+
+dotenv.config()
+
+describe('get contract type test', () => {
+	// Returns the contract type when provided with a valid chainId and provider.
+	it('test', async () => {
+		const chainId = '42161'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'
+
+		const x = await peanut.getContractDetails({
+			provider: provider,
+			address: contractAddress,
+		})
+
+		console.log(x)
+	})
+})

--- a/test/basic/getContractType.test.ts
+++ b/test/basic/getContractType.test.ts
@@ -27,4 +27,11 @@ describe('get contract type test', () => {
 		const contractAddress = '0xE538598941e4A25f471aEF9b1b5dFFD6eE0fDA54'
 		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual('ERC1155')
 	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return erc1155', async () => {
+		const chainId = '1'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0x0000000000000000000000000000000000000000'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual('NATIVE')
+	})
 })

--- a/test/basic/getContractType.test.ts
+++ b/test/basic/getContractType.test.ts
@@ -1,0 +1,30 @@
+import peanut, { interfaces } from '../../src/index' // import directly from source code
+import { ethers } from 'ethersv5' // v5
+import dotenv from 'dotenv'
+// import fetch from 'node-fetch'
+
+dotenv.config()
+
+describe('get contract type test', () => {
+	// Returns the contract type when provided with a valid chainId and provider.
+	it('should return the contract type when provided with a valid chainId and provider, this should return erc721', async () => {
+		const chainId = '42161'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xfAe39eC09730CA0F14262A636D2d7C5539353752'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual('ERC721')
+	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return erc20', async () => {
+		const chainId = '137'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual('ERC20')
+	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return erc1155', async () => {
+		const chainId = '10'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xE538598941e4A25f471aEF9b1b5dFFD6eE0fDA54'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual('ERC1155')
+	})
+})

--- a/test/live/advancedIntegration.test.ts
+++ b/test/live/advancedIntegration.test.ts
@@ -12,7 +12,7 @@ describe('Advanced Integration Tests', () => {
 		const linkDetails = {
 			chainId: 5,
 			tokenAmount: 0.0001,
-			tokenType: 0,
+
 			tokenAddress: ethers.constants.AddressZero,
 		}
 
@@ -52,13 +52,11 @@ describe('Advanced Integration Tests', () => {
 		console.log(getLinksFromTxResponse)
 	}, 1000000)
 
-	it('should create a link using the advanced methods (prepareTxs, signAndSubmitTx, getLinkFromHash) on polygon', async () => {
+	it.only('should create a link using the advanced methods (prepareTxs, signAndSubmitTx, getLinkFromHash) on polygon', async () => {
 		const linkDetails = {
 			chainId: 137,
 			tokenAmount: 1,
-			tokenType: 1,
 			tokenAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
-			tokenDecimals: 6,
 		}
 
 		const passwords = [await peanut.getRandomString(16)]

--- a/test/live/advancedIntegration.test.ts
+++ b/test/live/advancedIntegration.test.ts
@@ -1,0 +1,100 @@
+import peanut, { interfaces } from '../../src/index' // import directly from source code
+import { ethers } from 'ethersv5' // v5
+import dotenv from 'dotenv'
+// import fetch from 'node-fetch'
+
+dotenv.config()
+
+describe('Advanced Integration Tests', () => {
+	const TEST_WALLET_PRIVATE_KEY = process.env.TEST_WALLET_PRIVATE_KEY
+
+	it('should create a link using the advanced methods (prepareTxs, signAndSubmitTx, getLinkFromHash) on goerli', async () => {
+		const linkDetails = {
+			chainId: 5,
+			tokenAmount: 0.0001,
+			tokenType: 0,
+			tokenAddress: ethers.constants.AddressZero,
+		}
+
+		const passwords = [await peanut.getRandomString(16)]
+
+		const goerliProvider = await peanut.getDefaultProvider(String(linkDetails.chainId))
+		const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
+
+		const prepareTxsResponse = await peanut.prepareTxs({
+			linkDetails: linkDetails,
+			address: goerliWallet.address ?? '',
+			passwords: passwords,
+		})
+
+		console.log('prepareTxsResponse', prepareTxsResponse)
+
+		const signedTxsResponse: interfaces.ISignAndSubmitTxResponse[] = []
+
+		for (const tx of prepareTxsResponse.unsignedTxs) {
+			const x = await peanut.signAndSubmitTx({
+				structSigner: {
+					signer: goerliWallet,
+				},
+				unsignedTx: tx,
+			})
+
+			await x.tx.wait()
+			signedTxsResponse.push(x)
+		}
+
+		const getLinksFromTxResponse = await peanut.getLinksFromTx({
+			linkDetails,
+			txHash: signedTxsResponse[signedTxsResponse.length - 1].txHash,
+			passwords: passwords,
+		})
+
+		console.log(getLinksFromTxResponse)
+	}, 1000000)
+
+	it('should create a link using the advanced methods (prepareTxs, signAndSubmitTx, getLinkFromHash) on polygon', async () => {
+		const linkDetails = {
+			chainId: 137,
+			tokenAmount: 1,
+			tokenType: 1,
+			tokenAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+			tokenDecimals: 6,
+		}
+
+		const passwords = [await peanut.getRandomString(16)]
+
+		const polygonProvider = await peanut.getDefaultProvider(String(linkDetails.chainId))
+		const polygonWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', polygonProvider)
+
+		const prepareTxsResponse = await peanut.prepareTxs({
+			linkDetails: linkDetails,
+			address: polygonWallet.address ?? '',
+			passwords: passwords,
+		})
+
+		console.log('prepareTxsResponse', prepareTxsResponse)
+
+		const signedTxsResponse: interfaces.ISignAndSubmitTxResponse[] = []
+
+		for (const tx of prepareTxsResponse.unsignedTxs) {
+			const x = await peanut.signAndSubmitTx({
+				structSigner: {
+					signer: polygonWallet,
+				},
+				unsignedTx: tx,
+			})
+
+			await x.tx.wait()
+			console.log('tx submitted: ', x.tx)
+			signedTxsResponse.push(x)
+		}
+
+		const getLinksFromTxResponse = await peanut.getLinksFromTx({
+			linkDetails,
+			txHash: signedTxsResponse[signedTxsResponse.length - 1].txHash,
+			passwords: passwords,
+		})
+
+		console.log(getLinksFromTxResponse)
+	}, 1000000)
+})

--- a/test/live/live.test.ts
+++ b/test/live/live.test.ts
@@ -133,6 +133,24 @@ describe('goerli', function () {
 			9000
 		)
 	}, 60000)
+
+	it('should create a native link and claim it (without pasing in tokenType', async function () {
+		const goerliProvider = await peanut.getDefaultProvider(String(chainId))
+		const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
+		await createAndClaimLink(
+			{
+				structSigner: {
+					signer: goerliWallet,
+				},
+				linkDetails: {
+					chainId: chainId,
+					tokenAmount: tokenAmount,
+				},
+			},
+			9000
+		)
+	}, 60000)
+
 	it('should create an erc20 link and claim it', async function () {
 		const goerliProvider = await peanut.getDefaultProvider(String(chainId))
 		const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
@@ -152,6 +170,27 @@ describe('goerli', function () {
 					tokenDecimals: tokenDecimals,
 					tokenAddress: tokenAddress,
 					tokenType: 1, // 0 for ether, 1 for erc20, 2 for erc721, 3 for erc1155
+				},
+			},
+			9000
+		)
+	}, 180000)
+
+	it('should create an erc20 link and claim it (without passing in tokentype & tokendecimals', async function () {
+		const goerliProvider = await peanut.getDefaultProvider(String(chainId))
+		const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
+		const tokenAddress = '0x326C977E6efc84E512bB9C30f76E30c160eD06FB' // goerli LINK
+
+		// create link
+		await createAndClaimLink(
+			{
+				structSigner: {
+					signer: goerliWallet,
+				},
+				linkDetails: {
+					chainId: chainId,
+					tokenAmount: tokenAmount,
+					tokenAddress: tokenAddress,
 				},
 			},
 			9000


### PR DESCRIPTION
Changelog:
- introduced `getDefaultRpcUrl`: This is a wrapper function for `getDefaultProvider`, which only returns the URL so that the integrator can use their own provider type with the given URL.
- updated prepareTxs response: this was one of the discussed painpoints when implementing the sdk. We should not return an ethers type, bc not everyone will work with ethers. We now return `IPeanutUnsignedTransaction`, which holds the values the integrator needs to create a transaction themselves (to, value, data and nonce). Also updated the signAndSubmitTx to work with the new types. 
- introduced `getContractType`: This is a function that takes in a provider & the address of the contract, and returns the type EPeanutLinkType
- introduced `getContractDetails`: This calls the `getContractType` to get the type and uses this type to fetch the details from the contract. It will always return the type, and depending on the type other values (decimals, name, symbol) 
- Updated `validateLinkDetails` function to use `getContractDetails` if tokenType and tokenDecimals are undefined 

Extras: 
- wrote & updated tests for getContractDetails, getContractType, advancedIntegrations (prepareTxs, signAndSubmit and getLinkFromTxHash) and getContractDetails implementation (in createLink)