### PR TITLE
feat: ENS name & link format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1824,6 +1824,7 @@ async function getLinkDetails({ link, provider }: interfaces.IGetLinkDetailsPara
 		depositIndex: depositIdx,
 		contractVersion: contractVersion,
 		password: password,
+		senderAddress: senderAddress,
 		tokenType: deposit.contractType,
 		tokenAddress: deposit.tokenAddress,
 		tokenDecimals: tokenDecimals,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1698,6 +1698,7 @@ async function getLinkDetails({ link, provider }: interfaces.IGetLinkDetailsPara
 
 	let tokenAddress = deposit.tokenAddress
 	const tokenType = deposit.contractType
+	const senderAddress = deposit.senderAddress
 
 	let claimed = false
 	if (['v2', 'v3', 'v4'].includes(contractVersion)) {
@@ -1835,6 +1836,20 @@ async function getLinkDetails({ link, provider }: interfaces.IGetLinkDetailsPara
 		tokenURI: tokenURI,
 		metadata: metadata,
 	}
+}
+
+async function resolveToENSName({
+	address,
+	provider = null,
+}: {
+	address: string
+	provider?: ethers.providers.Provider
+}) {
+	if (provider == null) {
+		provider = await getDefaultProvider('1')
+	}
+	const ensName = await provider.lookupAddress(address)
+	return ensName
 }
 
 /**
@@ -2545,6 +2560,7 @@ const peanut = {
 	toggleVerbose,
 	trim_decimal_overflow,
 	verifySignature,
+	resolveToENSName,
 }
 
 export default peanut
@@ -2616,4 +2632,5 @@ export {
 	toggleVerbose,
 	trim_decimal_overflow,
 	verifySignature,
+	resolveToENSName,
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -246,11 +246,18 @@ export function getLinkFromParams(
 ) {
 	/* returns a link from the given parameters */
 
-	const link = baseUrl + '#?c=' + chainId + '&v=' + contractVersion + '&i=' + depositIdx + '&p=' + password
+	const link =
+		baseUrl +
+		'?c=' +
+		chainId +
+		'&v=' +
+		contractVersion +
+		'&i=' +
+		depositIdx +
+		(trackId ? '&t=' + trackId : '') +
+		'#p=' +
+		password
 
-	if (trackId != '') {
-		return link + '&t=' + trackId
-	}
 	return link
 }
 

--- a/test/basic/getLinkDetails.test.ts
+++ b/test/basic/getLinkDetails.test.ts
@@ -84,6 +84,17 @@ describe('getLinkDetails', function () {
 			console.log(linkDetails.depositDate)
 		}, 1000000)
 
+		it.only('should include senderAddress', async function () {
+			const link = 'https://peanut.to/claim#?c=137&v=v4&i=297&p=zoOnfUtvnMX1xt8A&t=ui'
+			// const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
+			const linkDetails = await peanut.getLinkDetails({ link })
+			console.log(linkDetails)
+			// should not be empty
+			expect(linkDetails).not.toBe(undefined)
+			expect(linkDetails.senderAddress).toBe('0x9647BB6a598c2675310c512e0566B60a5aEE6261')
+			console.log(linkDetails.senderAddress)
+		}, 1000000)
+
 		it('timestamp should be null if link already claimed', async function () {
 			const link = 'https://peanut.to/claim#?c=42161&v=v4&i=21&p=BJkAqGmZNYCZFBEH&t=sdk'
 			// const CHAIN_ID = 42161

--- a/test/basic/getLinkDetails.test.ts
+++ b/test/basic/getLinkDetails.test.ts
@@ -84,7 +84,7 @@ describe('getLinkDetails', function () {
 			console.log(linkDetails.depositDate)
 		}, 1000000)
 
-		it.only('should include senderAddress', async function () {
+		it('should include senderAddress', async function () {
 			const link = 'https://peanut.to/claim#?c=137&v=v4&i=297&p=zoOnfUtvnMX1xt8A&t=ui'
 			// const goerliWallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', goerliProvider)
 			const linkDetails = await peanut.getLinkDetails({ link })

--- a/test/basic/getLinksFromTx.test.ts
+++ b/test/basic/getLinksFromTx.test.ts
@@ -22,4 +22,23 @@ describe('getLinksFromTx eth mainnet', function () {
 
 		console.log(links)
 	}, 10000)
+
+	it('mainnet', async function () {
+		const tx_hash = '0xa082092246c81a7e10c15704f438d95e463ea64dc6444241651fcff309c180c7'
+		const linkDetails = {
+			chainId: 1,
+			tokenAmount: 0.01,
+			tokenType: 0,
+			tokenAddress: '0x0000000000000000000000000000000000000000',
+			trackId: 'trackId',
+		}
+
+		const links = await peanut.getLinksFromTx({
+			linkDetails: linkDetails,
+			txHash: tx_hash,
+			passwords: ['password1'],
+		})
+
+		console.log(links)
+	}, 10000)
 })

--- a/test/basic/resolveToENSName.test.ts
+++ b/test/basic/resolveToENSName.test.ts
@@ -8,4 +8,12 @@ describe('resolveToENSName', () => {
 		console.log(result)
 		expect(result).toBe(ensName)
 	}, 60000)
+
+	it('should resolve ENS name when using default provider', async () => {
+		const address = '0x2d826aD1EAD5c8a2bC46ab93d9D0c6BEe0d39918'
+		const ensName = null
+		const result = await peanut.resolveToENSName({ address })
+		console.log(result)
+		expect(result).toBe(ensName)
+	}, 60000)
 })

--- a/test/basic/resolveToENSName.test.ts
+++ b/test/basic/resolveToENSName.test.ts
@@ -1,0 +1,11 @@
+import * as peanut from '../../src/index'
+
+describe('resolveToENSName', () => {
+	it('should resolve ENS name when using default provider', async () => {
+		const address = '0x7fDCc4908bEF4f6F296f78a30A6b295069EE9e5d'
+		const ensName = 'borcherd.eth'
+		const result = await peanut.resolveToENSName({ address })
+		console.log(result)
+		expect(result).toBe(ensName)
+	}, 60000)
+})

--- a/test/live/api.test.ts
+++ b/test/live/api.test.ts
@@ -132,6 +132,48 @@ describe('Peanut API Integration Tests', function () {
 		links.push(resp.link)
 	}, 60000) // 60 seconds timeout
 
+	it('should create a link on Avalanche AVAX mainnet and claim it with api', async function () {
+		const apiToken = process.env.PEANUT_DEV_API_KEY ?? ''
+		peanut.toggleVerbose(true)
+
+		const chainId = 43114 // optimism goerli
+		const tokenAmount = 0.00001337
+		const tokenType = 0 // 0 for ether, 1 for erc20, 2 for erc721, 3 for erc1155
+		const provider = await peanut.getDefaultProvider(String(chainId))
+		const wallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY, provider)
+		setTimeout(() => {}, 9000)
+		const resp = await peanut.createLink({
+			structSigner: {
+				signer: wallet,
+			},
+			linkDetails: {
+				chainId: chainId,
+				tokenAmount: tokenAmount,
+				tokenType: tokenType,
+			},
+		})
+
+		// check status of link
+		setTimeout(() => {}, 4000)
+		console.log('getting link details now')
+		const status = await peanut.getLinkDetails({ provider: provider, link: resp.link })
+		console.log('status', status)
+
+		// claim link using api
+		const receiverAddress = optimism_goerli_wallet.address
+		setTimeout(() => {}, 9000)
+		const res = await peanut.claimLinkGasless({
+			link: resp.link,
+			recipientAddress: receiverAddress,
+			APIKey: apiToken,
+			baseUrl: API_URL,
+		})
+		expect(res.status).toBe('success')
+		console.log('claim link response', res.data)
+
+		links.push(resp.link)
+	}, 60000) // 60 seconds timeout
+
 	it('should create two links and claim them simultaneously', async function () {
 		const apiToken = process.env.PEANUT_DEV_API_KEY ?? ''
 

--- a/test/live/live.test.ts
+++ b/test/live/live.test.ts
@@ -117,7 +117,7 @@ describe('linea', function () {
 
 	console.log('getting fee data in test file')
 
-	it.only('should create a native link and claim it', async function () {
+	it('should create a native link and claim it', async function () {
 		const provider = await peanut.getDefaultProvider(String(chainId))
 		const wallet = new ethers.Wallet(TEST_WALLET_PRIVATE_KEY ?? '', provider)
 		peanut.toggleVerbose()


### PR DESCRIPTION
Changelog: 
- Made function to resolve to ENS name. Takes in address and optional provider. Returns the ENS name OR null if there is no ens name found
- Updated getLinkDetails to return the senderAddress of the deposit & updated test 
- Updated structure of the link: password is now the only param hidden behind the # for the server. 