### PR TITLE
feat: added raw onchain deposit info to getLinkDetails object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 prompt.md
 playground/
 !playground/preprompt.py
+playground.ts
+playground.js
 dist/
 archive/
 src/data/package.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -1817,6 +1817,15 @@ async function getLinkDetails({ link, provider }: interfaces.IGetLinkDetailsPara
 		tokenAmount = '1'
 	}
 
+	// format deposit to string values
+	const depositCopy = {}
+	for (const key in deposit) {
+		if (isNaN(Number(key))) {
+			// Only copy named properties
+			depositCopy[key] = deposit[key].toString()
+		}
+	}
+
 	return {
 		link: link,
 		chainId: chainId,
@@ -1834,6 +1843,7 @@ async function getLinkDetails({ link, provider }: interfaces.IGetLinkDetailsPara
 		depositDate: depositDate,
 		tokenURI: tokenURI,
 		metadata: metadata,
+		rawOnchainDepositInfo: depositCopy,
 	}
 }
 


### PR DESCRIPTION
added raw onchain deposit info to getLinkDetails object

Was needed for debugging the Silk bug. Thought why not keep it.