### PR TITLE
chore: update type input on getLatestContractVersion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2346,7 +2346,7 @@ function getLatestContractVersion({
 	experimental = false,
 }: {
 	chainId: string
-	type: string
+	type: 'normal' | 'batch'
 	experimental?: boolean
 }): string {
 	try {


### PR DESCRIPTION
Now only takes 'normal' or 'batch'