### PR TITLE
feat: fetch decimals and tokentype dynamically

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -668,11 +668,22 @@ async function prepareTxs({
 	passwords = [],
 	provider,
 }: interfaces.IPrepareTxsParams): Promise<interfaces.IPrepareTxsResponse> {
+	if (!provider) {
+		try {
+			provider = await getDefaultProvider(String(linkDetails.chainId))
+		} catch (error) {
+			throw new interfaces.SDKStatus(
+				interfaces.EPrepareCreateTxsStatusCodes.ERROR_GETTING_DEFAULT_PROVIDER,
+				'Error getting the default provider'
+			)
+		}
+	}
+
 	if (peanutContractVersion == null) {
 		peanutContractVersion = getLatestContractVersion({ chainId: linkDetails.chainId.toString(), type: 'normal' })
 	}
 	try {
-		linkDetails = validateLinkDetails(linkDetails, passwords, numberOfLinks)
+		linkDetails = await validateLinkDetails(linkDetails, passwords, numberOfLinks, provider)
 	} catch (error) {
 		throw new interfaces.SDKStatus(
 			interfaces.EPrepareCreateTxsStatusCodes.ERROR_VALIDATING_LINK_DETAILS,
@@ -983,11 +994,28 @@ async function getTxReceiptFromHash(
 	return txReceipt
 }
 
-function validateLinkDetails(
+async function validateLinkDetails(
 	linkDetails: interfaces.IPeanutLinkDetails,
 	passwords: string[],
-	numberOfLinks: number
-): interfaces.IPeanutLinkDetails {
+	numberOfLinks: number,
+	provider: ethers.providers.Provider
+): Promise<interfaces.IPeanutLinkDetails> {
+	linkDetails.tokenAddress = linkDetails.tokenAddress ?? '0x0000000000000000000000000000000000000000'
+
+	if (!linkDetails.tokenDecimals || !linkDetails.tokenType) {
+		try {
+			const contractDetails = await getContractDetails({
+				address: linkDetails.tokenAddress,
+				provider: provider,
+			})
+
+			linkDetails.tokenType = contractDetails.type
+			contractDetails.decimals && (linkDetails.tokenDecimals = contractDetails.decimals)
+		} catch (error) {
+			throw new Error('Contract type not supported')
+		}
+	}
+
 	if (!linkDetails || !linkDetails.chainId || !linkDetails.tokenAmount) {
 		throw new Error(
 			'validateLinkDetails function requires linkDetails object with chainId and tokenAmount properties'
@@ -1004,7 +1032,6 @@ function validateLinkDetails(
 	}
 
 	// Use nullish coalescing operator to provide default values
-	linkDetails.tokenAddress = linkDetails.tokenAddress ?? '0x0000000000000000000000000000000000000000'
 	linkDetails.tokenType = linkDetails.tokenType ?? 0
 	linkDetails.tokenId = linkDetails.tokenId ?? 0
 	linkDetails.baseUrl = linkDetails.baseUrl ?? 'https://peanut.to/claim'
@@ -1064,7 +1091,7 @@ async function createLink({
 		getLatestContractVersion({ chainId: linkDetails.chainId.toString(), type: 'normal' })
 	}
 	password = password || (await getRandomString(16))
-	linkDetails = validateLinkDetails(linkDetails, [password], 1)
+	linkDetails = await validateLinkDetails(linkDetails, [password], 1, structSigner.signer.provider)
 	const provider = structSigner.signer.provider
 
 	// Prepare the transactions
@@ -1126,7 +1153,7 @@ async function createLinks({
 		getLatestContractVersion({ chainId: linkDetails.chainId.toString(), type: 'normal' })
 	}
 	passwords = passwords || (await Promise.all(Array.from({ length: numberOfLinks }, () => getRandomString(16))))
-	linkDetails = validateLinkDetails(linkDetails, passwords, numberOfLinks)
+	linkDetails = await validateLinkDetails(linkDetails, passwords, numberOfLinks, structSigner.signer.provider)
 	const provider = structSigner.signer.provider
 
 	// Prepare the transactions
@@ -2451,6 +2478,113 @@ async function makeReclaimGasless({
 	}
 }
 
+/**
+ * gets the contract type
+ */
+async function getContractType({
+	provider,
+	address,
+}: {
+	provider: ethers.providers.Provider
+	address: string
+}): Promise<interfaces.EPeanutLinkType> {
+	const minimalABI = [
+		'function supportsInterface(bytes4) view returns (bool)',
+		'function totalSupply() view returns (uint256)',
+		'function balanceOf(address) view returns (uint256)',
+	]
+
+	// Interface Ids for ERC721 and ERC1155
+	const ERC721_INTERFACE_ID = '0x80ac58cd' // ERC721
+	const ERC1155_INTERFACE_ID = '0xd9b67a26' // ERC1155
+
+	const contract = new ethers.Contract(address, minimalABI, provider)
+
+	const isERC721 = await supportsInterface(contract, ERC721_INTERFACE_ID)
+	const isERC1155 = await supportsInterface(contract, ERC1155_INTERFACE_ID)
+	let isERC20 = false
+
+	// Check for ERC20 if it's not ERC721 or ERC1155
+	if (!isERC721 && !isERC1155) {
+		isERC20 = await contract
+			.totalSupply()
+			.then(() => true)
+			.catch(() => false)
+	}
+
+	if (address.toLowerCase() === ethers.constants.AddressZero.toLowerCase()) return 0
+	if (isERC20) return 1
+	if (isERC721) return 2
+	if (isERC1155) return 3
+}
+
+async function supportsInterface(contract, interfaceId) {
+	try {
+		return await contract.supportsInterface(interfaceId)
+	} catch (error) {
+		return false
+	}
+}
+
+async function getContractDetails({
+	address,
+	provider,
+}: {
+	address: string
+	provider: ethers.providers.Provider
+}): Promise<{ type: interfaces.EPeanutLinkType; decimals?: number; name?: string; symbol?: string }> {
+	//get the contract type
+	const contractType = await getContractType({ address: address, provider: provider })
+	//@ts-ignore
+	const batchprov = new ethers.providers.JsonRpcBatchProvider(provider.connection.url)
+
+	config.verbose && console.log('contractType: ', contractType)
+	switch (contractType) {
+		case 0: {
+			return {
+				type: 0,
+				decimals: 18,
+			}
+		}
+		case 1: {
+			const contract = new ethers.Contract(address, ERC20_ABI, batchprov)
+			const [name, symbol, decimals] = await Promise.all([
+				contract.name(),
+				contract.symbol(),
+				contract.decimals(),
+			])
+			config.verbose && console.log('details: ', [name, symbol, decimals])
+			return {
+				type: 1,
+				name: name,
+				symbol: symbol,
+				decimals: decimals,
+			}
+		}
+		case 2: {
+			const contract = new ethers.Contract(address, ERC721_ABI, batchprov)
+			const [fetchedName, fetchedSymbol] = await Promise.all([contract.name(), contract.symbol()])
+			config.verbose && console.log('details: ', [fetchedName, fetchedSymbol])
+			return {
+				type: 2,
+				name: fetchedName,
+				symbol: fetchedSymbol,
+			}
+		}
+		case 3: {
+			const contract = new ethers.Contract(address, ERC1155_ABI, batchprov)
+			const [fetchedName, fetchedSymbol] = await Promise.all([contract.name(), contract.symbol()])
+			config.verbose && console.log('details: ', [fetchedName, fetchedSymbol])
+			return {
+				type: 3,
+				name: fetchedName,
+				symbol: fetchedSymbol,
+				decimals: null,
+			}
+		}
+	}
+}
+
 const peanut = {
 	CHAIN_DETAILS,
 	LATEST_STABLE_BATCHER_VERSION,
@@ -2529,6 +2663,8 @@ const peanut = {
 	makeGaslessReclaimPayload,
 	prepareGaslessReclaimTx,
 	EIP3009Tokens,
+	getContractType,
+	getContractDetails,
 }
 
 export default peanut
@@ -2611,4 +2747,6 @@ export {
 	makeGaslessReclaimPayload,
 	prepareGaslessReclaimTx,
 	EIP3009Tokens,
+	getContractType,
+	getContractDetails,
 }

--- a/test/basic/getContractDetails.test.ts
+++ b/test/basic/getContractDetails.test.ts
@@ -1,0 +1,22 @@
+import peanut, { interfaces } from '../../src/index' // import directly from source code
+import { ethers } from 'ethersv5' // v5
+import dotenv from 'dotenv'
+// import fetch from 'node-fetch'
+
+dotenv.config()
+
+describe('get contract type test', () => {
+	// Returns the contract type when provided with a valid chainId and provider.
+	it('test', async () => {
+		const chainId = '42161'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'
+
+		const x = await peanut.getContractDetails({
+			provider: provider,
+			address: contractAddress,
+		})
+
+		console.log(x)
+	})
+})

--- a/test/basic/getContractType.test.ts
+++ b/test/basic/getContractType.test.ts
@@ -1,0 +1,37 @@
+import peanut, { interfaces } from '../../src/index' // import directly from source code
+import { ethers } from 'ethersv5' // v5
+import dotenv from 'dotenv'
+// import fetch from 'node-fetch'
+
+dotenv.config()
+
+describe('get contract type test', () => {
+	// Returns the contract type when provided with a valid chainId and provider.
+	it('should return the contract type when provided with a valid chainId and provider, this should return 2 for erc721', async () => {
+		const chainId = '42161'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xfAe39eC09730CA0F14262A636D2d7C5539353752'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual(2)
+	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return 1 for erc20', async () => {
+		const chainId = '137'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual(1)
+	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return 3 for erc1155', async () => {
+		const chainId = '10'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0xE538598941e4A25f471aEF9b1b5dFFD6eE0fDA54'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual(3)
+	})
+
+	it('should return the contract type when provided with a valid chainId and provider, this should return 0 for NATIVE', async () => {
+		const chainId = '1'
+		const provider = await peanut.getDefaultProvider(chainId)
+		const contractAddress = '0x0000000000000000000000000000000000000000'
+		await expect(peanut.getContractType({ provider, address: contractAddress })).resolves.toEqual(0)
+	})
+})


### PR DESCRIPTION
- introduced getContractType: This is a function that takes in a provider & the address of the contract, and returns the type EPeanutLinkType
- introduced getContractDetails: This calls the getContractType to get the type and uses this type to fetch the details from the contract. It will always return the type, and depending on the type other values (decimals, name, symbol)
- Updated validateLinkDetails function to use getContractDetails if tokenType and tokenDecimals are undefined