### PR TITLE
Wait for receipt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -981,9 +981,10 @@ async function getTxReceiptFromHash(
 	provider?: ethers.providers.Provider
 ): Promise<TransactionReceipt> {
 	provider = provider ?? (await getDefaultProvider(chainId))
-	const txReceipt = await provider.getTransactionReceipt(txHash)
-	// throw error if txReceipt is null
-	if (txReceipt == null) {
+	let txReceipt: TransactionReceipt
+	try {
+		txReceipt = await provider.waitForTransaction(txHash, 1, 10000)
+	} catch (e: any) {
 		throw new Error('Could not fetch transaction receipt')
 	}
 	return txReceipt


### PR DESCRIPTION
Previously just a `getReceipt` function was called on the provider. This could return null if the provider has not yet indexed a transaction that was executed just recently. Now we use `waitForTransaction` there with a timeout of 10 seconds to make sure that we get the receipt.