### PR TITLE
Add get raw params from link

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -417,6 +417,14 @@ export interface ILinkParams {
 	trackId: string
 }
 
+export interface ILinkRawParams {
+	chainId: string
+	contractVersion: string
+	depositIndices: string
+	password: string
+	trackId: string
+}
+
 export interface IPeanutV4_2Deposit {
 	pubKey20: string
 	amount: BigNumber

--- a/src/util.ts
+++ b/src/util.ts
@@ -203,9 +203,11 @@ export async function getRandomString(n: number = 16): Promise<string> {
 }
 
 /**
- * Returns the parameters from a link
+ * Returns raw params from the link (so just unpacks the params)
+ * without converting deposit index to a number
+ * @param link 
  */
-export function getParamsFromLink(link: string): interfaces.ILinkParams {
+export function getRawParamsFromLink(link: string): interfaces.ILinkRawParams {
 	/* returns the parameters from a link */
 	let url
 	try {
@@ -233,15 +235,27 @@ export function getParamsFromLink(link: string): interfaces.ILinkParams {
 	const _chainId: string = params.get('c') ?? '' // can be chain name or chain id
 	let chainId: string = _chainId
 	const contractVersion = params.get('v') ?? ''
-	let depositIdx: string | number = params.get('i') ?? ''
-	depositIdx = parseInt(depositIdx)
+	let depositIndices: string | number = params.get('i') ?? ''
 	const password = params.get('p') ?? ''
 	let trackId = '' // optional
 	if (params.get('t')) {
 		trackId = params.get('t') ?? ''
 	}
+	return { chainId, contractVersion, depositIndices, password, trackId }
+}
 
-	return { chainId, contractVersion, depositIdx, password, trackId }
+/**
+ * Returns the parameters from a link
+ */
+export function getParamsFromLink(link: string): interfaces.ILinkParams {
+	const { chainId, contractVersion, depositIndices, password, trackId } = getRawParamsFromLink(link)
+	return {
+		chainId,
+		contractVersion,
+		password,
+		depositIdx: parseInt(depositIndices),
+		trackId,
+	}
 }
 
 /**


### PR DESCRIPTION
1. Create `getRawParamsFromLink` that just unpacks the url and returns its contents as strings
2. Use it in raffle-related functions to get link's password and chain id faster. Previously we would generate all the slot links from a raffle link, take the first one and get its params, which on large raffles would take a lot of time (like 10 seconds for a raffle with 10k slots).