### PR TITLE
feat: update setFeeOptions to take optional provider & chainId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@squirrel-labs/peanut-sdk",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"description": "The Peanut Protocol SDK! Check out the documentation at https://docs.peanut.to",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -579,6 +579,11 @@ export enum ESignAndSubmitTx {
 	ERROR_INSUFFICIENT_NATIVE_TOKEN,
 }
 
+export enum ESetFeeOptionsStatusCodes {
+	ERROR_PROVIDER_OR_CHAINID_REQUIRED,
+	ERROR_PROVIDER_CHAINID_MISMATCH,
+}
+
 export enum EGetLinkFromTxStatusCodes {
 	ERROR_GETTING_TX_RECEIPT_FROM_HASH,
 }
@@ -622,6 +627,7 @@ export type allErrorEnums =
 	| EXChainStatusCodes
 	| ERaffleErrorCodes
 	| EGenericErrorCodes // New enum added here
+	| ESetFeeOptionsStatusCodes
 
 export class SDKStatus extends Error {
 	code: allErrorEnums

--- a/src/index.ts
+++ b/src/index.ts
@@ -486,7 +486,8 @@ async function getEIP1559Tip(chainId: string): Promise<ethers.BigNumber | null> 
 async function setFeeOptions({
 	txOptions,
 	unsignedTx,
-	provider,
+	provider = undefined,
+	chainId = undefined,
 	eip1559 = true,
 	maxFeePerGas = null,
 	maxFeePerGasMultiplier = 1.2,
@@ -498,7 +499,8 @@ async function setFeeOptions({
 }: {
 	txOptions?: any
 	unsignedTx?: interfaces.IPeanutUnsignedTransaction
-	provider: Provider
+	provider?: Provider | undefined
+	chainId?: string | undefined
 	eip1559?: boolean
 	maxFeePerGas?: ethers.BigNumber | null
 	maxFeePerGasMultiplier?: number
@@ -508,8 +510,14 @@ async function setFeeOptions({
 	maxPriorityFeePerGasMultiplier?: number
 	gasLimitMultiplier?: number
 }) {
-	// eip1559 = true
 	config.verbose && console.log('Setting tx options...')
+
+	if (!provider && !chainId) {
+		throw new Error('Either provider or chainId must be provided')
+	} else if (chainId && !provider) {
+		provider = await getDefaultProvider(chainId)
+	}
+
 	let feeData
 	// if not txOptions, create it (oneliner)
 	txOptions = txOptions || {}
@@ -523,8 +531,10 @@ async function setFeeOptions({
 		throw error
 	}
 
-	const chainId = Number(await provider.getNetwork().then((network: any) => network.chainId))
-	const chainDetails = CHAIN_DETAILS[chainId]
+	const _chainId = chainId
+		? chainId
+		: (await provider.getNetwork().then((network: any) => network.chainId)).toString()
+	const chainDetails = CHAIN_DETAILS[_chainId]
 
 	if (gasLimit) {
 		txOptions.gasLimit = gasLimit
@@ -550,7 +560,7 @@ async function setFeeOptions({
 	// Check if EIP-1559 is supported
 	// if on milkomeda or bnb or linea, set eip1559 to false
 	// Even though linea is eip1559 compatible, it is more reliable to use the good old gasPrice
-	if ([2001, 200101, 56, 59144, 59140, 534352, 5000, 5001].includes(chainId)) {
+	if (['2001', '200101', '56', '59144', '59140', '534352', '5000', '5001'].includes(_chainId)) {
 		eip1559 = false
 		config.verbose && console.log('Setting eip1559 to false as an exception')
 	} else if (chainDetails && chainDetails.features) {
@@ -588,14 +598,14 @@ async function setFeeOptions({
 				// for some chains, like arbitrum or base, providers tend to return an incorrect maxPriorityFeePerGas
 				// Sanity check so that it's never more than the base fee.
 				// exception: linea, where baseFee is hardcoded to 7 gwei (minimum allowed)
-				if (![59144, 59140].includes(chainId)) {
+				if (![59144, 59140].includes(_chainId)) {
 					if (BigInt(txOptions.maxPriorityFeePerGas) > lastBaseFeePerGas) {
 						txOptions.maxPriorityFeePerGas = lastBaseFeePerGas.toString()
 					}
 				}
 
 				// for polygon (137), set priority fee to min 40 gwei (they have a minimum of 30 for spam prevention)
-				if (chainId == 137) {
+				if (_chainId == 137) {
 					const minPriorityFee = ethers.utils.parseUnits('40', 'gwei')
 					if (ethers.BigNumber.from(txOptions.maxPriorityFeePerGas).lt(minPriorityFee)) {
 						txOptions.maxPriorityFeePerGas = minPriorityFee.toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,7 @@ async function setFeeOptions({
 	//TODO: Technically, if the provided tx Options have all the data filled out, we wouldn't have to check chainid or provider, because there's nth to do. Maybe Implememt an entry check for that
 	config.verbose && console.log('Setting tx options...')
 
-	let _chainId: string = ''
+	let _chainId: string = chainId || ''
 
 	if (!provider && !chainId) {
 		throw new interfaces.SDKStatus(
@@ -523,16 +523,10 @@ async function setFeeOptions({
 	} else if (chainId && !provider) {
 		_chainId = chainId
 		provider = await getDefaultProvider(chainId)
-	} else if (chainId && provider) {
+	} else if (!chainId && provider) {
 		// if chainId and provider are both provided, check if they match
 		const network = await provider.getNetwork()
-		if (network.chainId.toString() !== chainId) {
-			throw new interfaces.SDKStatus(
-				interfaces.ESetFeeOptionsStatusCodes.ERROR_PROVIDER_CHAINID_MISMATCH,
-				'ChainId and provider chainId do not match'
-			)
-		}
-		_chainId = chainId
+		_chainId = network.chainId.toString()
 	}
 
 	let feeData

--- a/src/index.ts
+++ b/src/index.ts
@@ -510,6 +510,7 @@ async function setFeeOptions({
 	maxPriorityFeePerGasMultiplier?: number
 	gasLimitMultiplier?: number
 }) {
+	//TODO: Technically, if the provided tx Options have all the data filled out, we wouldn't have to check chainid or provider, because there's nth to do. Maybe Implememt an entry check for that
 	config.verbose && console.log('Setting tx options...')
 
 	let _chainId: string = ''

--- a/test/basic/setFeeOptions.test.ts
+++ b/test/basic/setFeeOptions.test.ts
@@ -85,15 +85,4 @@ describe('setFeeOptions function', () => {
 			})
 		).rejects.toThrow()
 	}, 30000)
-
-	it('should check if the provider and chainId are on the same network', async () => {
-		const provider = await getDefaultProvider('137')
-
-		await expect(
-			setFeeOptions({
-				chainId: '5000',
-				provider,
-			})
-		).rejects.toThrow('ChainId and provider chainId do not match')
-	}, 30000)
 })

--- a/test/basic/setFeeOptions.test.ts
+++ b/test/basic/setFeeOptions.test.ts
@@ -85,4 +85,15 @@ describe('setFeeOptions function', () => {
 			})
 		).rejects.toThrow()
 	}, 30000)
+
+	it('should check if the provider and chainId are on the same network', async () => {
+		const provider = await getDefaultProvider('137')
+
+		await expect(
+			setFeeOptions({
+				chainId: '5000',
+				provider,
+			})
+		).rejects.toThrow('ChainId and provider chainId do not match')
+	}, 30000)
 })

--- a/test/basic/setFeeOptions.test.ts
+++ b/test/basic/setFeeOptions.test.ts
@@ -37,6 +37,18 @@ describe('setFeeOptions function', () => {
 		expect(txOptions).toHaveProperty('gasPrice')
 	}, 30000)
 
+	it('should correctly set fee options for non-EIP-1559 chains with only chainId', async () => {
+		const txOptions = await setFeeOptions({
+			chainId: '5000',
+		})
+
+		expect(txOptions).toHaveProperty('gasPrice')
+	}, 30000)
+
+	it('should throw error if no chainId & provider are passed in', async () => {
+		await expect(setFeeOptions({})).rejects.toThrow('Either provider or chainId must be provided')
+	}, 30000)
+
 	it('should correctly set gas limit for specific chains', async () => {
 		const provider = await getDefaultProvider('137')
 


### PR DESCRIPTION
We were running into an issue where the function to setFeeOptions takes an ethers provider, but its not as trivial to get this in a wagmi environment. This pr makes the provider optional and also takes in a chainId as argument. If the chainId & provider are both undefined, it throws an error. If the chainId is defined but the provider is not, it gets the default provider for that chain. If the provider is defined, it uses that provider. 

The chainId comparison was still in Number, changed this to string too. 

Also wrote two new tests to test these cases