### PR TITLE
Inroduce recipient-bound links

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -159,7 +159,8 @@ export interface IPrepareDepositTxsParams {
 	passwords: string[]
 	provider?: ethers.providers.Provider
 	recipient?: string // only this address will be able to claim if set
-	reclaimableAfter?: number  // timestamp in seconds
+	// after what timestamp (in seconds) is the recipient-bound link reclaimable by the sender
+	reclaimableAfter?: number
 }
 
 export interface IPrepareDepositTxsResponse {

--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -76,6 +76,8 @@ export interface ICreateLinkParams {
 	linkDetails: IPeanutLinkDetails
 	peanutContractVersion?: string
 	password?: string
+	recipient?: string // only this address will be able to claim if set
+	reclaimableAfter?: number  // timestamp in seconds
 }
 
 //createLinks
@@ -156,6 +158,8 @@ export interface IPrepareDepositTxsParams {
 	numberOfLinks?: number
 	passwords: string[]
 	provider?: ethers.providers.Provider
+	recipient?: string // only this address will be able to claim if set
+	reclaimableAfter?: number  // timestamp in seconds
 }
 
 export interface IPrepareDepositTxsResponse {

--- a/test/basic/getLatestContractVersion.test.ts
+++ b/test/basic/getLatestContractVersion.test.ts
@@ -4,7 +4,25 @@ describe('getLatestContractVersion', () => {
 	const expectedVersionBatch = 'Bv4.4'
 	const types = ['normal', 'batch']
 
-	const chainIds = ['5', '137', '5000', '5001']
+	const chainIds = [
+		// Mainnets
+		'137',
+		'5000',
+		'10',
+		'8453',
+		'42161',
+		'100',
+		'43114',
+		'59144',
+		'324',
+		'534352',
+		'42220',
+		// Testnets
+		'11155111',
+		'80001',
+		'300',
+		'44787',
+	]
 	chainIds.forEach((chainId) => {
 		types.forEach((type) => {
 			const isExperimental = [true, false]
@@ -19,8 +37,25 @@ describe('getLatestContractVersion', () => {
 		})
 	})
 
-	const chainIdsExceptions = ['1', '324', '300']
-	chainIdsExceptions.forEach((chainId) => {
+	// TODO: fix bnb. Could not deploy the v4.4 peanut version
+	// due to problems with bscscan api keys
+	const chainIdsExceptionsV4_3 = ['5', '5001', '56']
+	chainIdsExceptionsV4_3.forEach((chainId) => {
+		types.forEach((type) => {
+			const isExperimental = [true, false]
+			isExperimental.forEach((experimental) => {
+				if (type === 'normal') {
+					it(`EXCEPTIONS: chain ${chainId} ${type} experimental: ${experimental}`, () => {
+						const latestContractVersion = peanut.getLatestContractVersion({ chainId, type, experimental })
+						expect(latestContractVersion).toBe('v4.3')
+					})
+				}
+			})
+		})
+	})
+
+	const chainIdsExceptionsV4_2 = ['1']
+	chainIdsExceptionsV4_2.forEach((chainId) => {
 		types.forEach((type) => {
 			const isExperimental = [true, false]
 			isExperimental.forEach((experimental) => {


### PR DESCRIPTION
Make `prepareDepositTxs` and `createLink` functions support recipient-bound deposits. Does not work for batch deposits.