### PR TITLE
fix: check tokentype in validateLinkDetails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1152,6 +1152,10 @@ async function getTxReceiptFromHash(
 	return txReceipt
 }
 
+/**
+ * function that validates all the details of the link.
+ * TODO: rename to something that indicates that it also updates the linkDetails
+ */
 async function validateLinkDetails(
 	linkDetails: interfaces.IPeanutLinkDetails,
 	passwords: string[],
@@ -1160,6 +1164,7 @@ async function validateLinkDetails(
 ): Promise<interfaces.IPeanutLinkDetails> {
 	linkDetails.tokenAddress = linkDetails.tokenAddress ?? '0x0000000000000000000000000000000000000000'
 
+	// TODO: this should be rewritten to be more efficient/clear
 	if (linkDetails.tokenDecimals == undefined || linkDetails.tokenType == undefined) {
 		if (
 			linkDetails.tokenType == interfaces.EPeanutLinkType.erc20 ||
@@ -1226,7 +1231,7 @@ async function validateLinkDetails(
 			linkDetails.tokenType == interfaces.EPeanutLinkType.erc1155
 		) || linkDetails.tokenDecimals != null,
 		'tokenDecimals must be provided for ERC20 and ERC1155 tokens'
-	)
+	) // this can be removed since we do the check at the top for decimals and
 
 	if (
 		linkDetails.tokenType !== interfaces.EPeanutLinkType.native &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1160,7 +1160,11 @@ async function validateLinkDetails(
 ): Promise<interfaces.IPeanutLinkDetails> {
 	linkDetails.tokenAddress = linkDetails.tokenAddress ?? '0x0000000000000000000000000000000000000000'
 
-	if (linkDetails.tokenDecimals == undefined || linkDetails.tokenType == undefined) {
+	if (
+		(linkDetails.tokenType == interfaces.EPeanutLinkType.erc20 ||
+			linkDetails.tokenType == interfaces.EPeanutLinkType.native) &&
+		(linkDetails.tokenDecimals == undefined || linkDetails.tokenType == undefined)
+	) {
 		try {
 			const contractDetails = await getTokenContractDetails({
 				address: linkDetails.tokenAddress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1160,21 +1160,23 @@ async function validateLinkDetails(
 ): Promise<interfaces.IPeanutLinkDetails> {
 	linkDetails.tokenAddress = linkDetails.tokenAddress ?? '0x0000000000000000000000000000000000000000'
 
-	if (
-		(linkDetails.tokenType == interfaces.EPeanutLinkType.erc20 ||
-			linkDetails.tokenType == interfaces.EPeanutLinkType.native) &&
-		(linkDetails.tokenDecimals == undefined || linkDetails.tokenType == undefined)
-	) {
-		try {
-			const contractDetails = await getTokenContractDetails({
-				address: linkDetails.tokenAddress,
-				provider: provider,
-			})
+	if (linkDetails.tokenDecimals == undefined || linkDetails.tokenType == undefined) {
+		if (
+			linkDetails.tokenType == interfaces.EPeanutLinkType.erc20 ||
+			linkDetails.tokenType == interfaces.EPeanutLinkType.native ||
+			linkDetails.tokenType == undefined
+		) {
+			try {
+				const contractDetails = await getTokenContractDetails({
+					address: linkDetails.tokenAddress,
+					provider: provider,
+				})
 
-			linkDetails.tokenType = contractDetails.type
-			contractDetails.decimals && (linkDetails.tokenDecimals = contractDetails.decimals)
-		} catch (error) {
-			throw new Error('Contract type not supported')
+				linkDetails.tokenType = contractDetails.type
+				contractDetails.decimals && (linkDetails.tokenDecimals = contractDetails.decimals)
+			} catch (error) {
+				throw new Error('Contract type not supported')
+			}
 		}
 	}
 


### PR DESCRIPTION
Changes the check to fetch the tokenType/decimals. Previously, it would check if either the decimals or tokenType were undefined. If any of those were undefined, it'd refetch the decimals AND type.
However, for erc721 and erc1155, the decimals can be undefined. I've changed the check. 