### PR TITLE
feat: allow string type on `prepareDepositTxs`

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -30,7 +30,7 @@ export enum EPeanutLinkType {
 
 export interface IPeanutLinkDetails {
 	chainId: string
-	tokenAmount: number
+	tokenAmount: number | string
 	tokenType?: EPeanutLinkType
 	tokenAddress?: string
 	tokenId?: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -793,7 +793,7 @@ function trim_decimal_overflow(_n: number, decimals: number) {
 	return arr[0] + '.' + fraction
 }
 
-function getStringAmount(amount: number | string, decimals: number) {
+function getStringAmount(amount: interfaces.IPeanutLinkDetails['tokenAmount'], decimals: number) {
 	if (typeof amount === 'string') {
 		return amount
 	} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -793,6 +793,14 @@ function trim_decimal_overflow(_n: number, decimals: number) {
 	return arr[0] + '.' + fraction
 }
 
+function getStringAmount(amount: number | string, decimals: number) {
+	if (typeof amount === 'string') {
+		return amount
+	} else {
+		return trim_decimal_overflow(amount, decimals)
+	}
+}
+
 /**
  * Returns an array of transactions necessary to create a link (e.g. 1. approve, 2. makeDeposit)
  * all values obligatory.
@@ -827,7 +835,7 @@ async function prepareDepositTxs({
 			'Error validating link details: please make sure all required fields are provided and valid'
 		)
 	}
-	const tokenAmountString = trim_decimal_overflow(linkDetails.tokenAmount, linkDetails.tokenDecimals!)
+	const tokenAmountString = getStringAmount(linkDetails.tokenAmount, linkDetails.tokenDecimals!)
 	const tokenAmountBigNum = ethers.utils.parseUnits(tokenAmountString, linkDetails.tokenDecimals)
 	const totalTokenAmount = tokenAmountBigNum.mul(numberOfLinks)
 
@@ -1267,7 +1275,7 @@ async function validateLinkDetails(
 		throw new Error('need to provide tokenAddress if tokenType is not 0')
 	}
 
-	const tokenAmountString = trim_decimal_overflow(linkDetails.tokenAmount, linkDetails.tokenDecimals!)
+	const tokenAmountString = getStringAmount(linkDetails.tokenAmount, linkDetails.tokenDecimals!)
 	const tokenAmountBigNum = ethers.utils.parseUnits(tokenAmountString, linkDetails.tokenDecimals) // v5
 	assert(tokenAmountBigNum.gt(0), 'tokenAmount must be greater than 0')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3225,4 +3225,5 @@ export {
 	getTxReceiptFromHash,
 	getTokenBalance,
 	compareVersions,
+	getStringAmount,
 }

--- a/src/raffle.ts
+++ b/src/raffle.ts
@@ -15,7 +15,7 @@ import {
 	getLinksFromTx,
 	interfaces,
 	prepareApproveERC20Tx,
-	trim_decimal_overflow,
+	getStringAmount,
 } from '.'
 import { getRawParamsFromLink, validateUserName, compareVersions } from './util'
 import {
@@ -174,7 +174,7 @@ export async function prepareRaffleDepositTxs({
 
 	// Convert linkDetails.tokenAmount to BigNumber.
 	// Used only for ETH and ERC20 raffles.
-	const tokenAmountString = trim_decimal_overflow(linkDetails.tokenAmount, linkDetails.tokenDecimals)
+	const tokenAmountString = getStringAmount(linkDetails.tokenAmount, linkDetails.tokenDecimals)
 	const tokenAmountBigNum = ethers.utils.parseUnits(tokenAmountString, linkDetails.tokenDecimals)
 
 	const peanutVaultAddress = getContractAddress(linkDetails.chainId, peanutContractVersion)


### PR DESCRIPTION
# WHAT

Allow `string` type in link creation

# WHY

It is impossible to send some token amounts, especially if the `decimal = 18`

For example, I want to send `370637.59981187013726614` MEOW tokens, since this is valid amount with 18 decimals. However, SDK forces me to send `number` type. It is impossible to represent this string amount in terms of `number`.

# HOW

Added util called `getStringAmount`, which either accepts number or string. If the accepted type is number, it behaves as before to make it backward compatible. If the input is string (which is also now supported by modifying `IPeanutLinkDetails`), the input amount is accepted as it is.   



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `tokenAmount` property to accept both numeric and string values for greater flexibility.
	- Introduced a new function to improve handling of `tokenAmount`, ensuring robust input processing across multiple functions.

- **Bug Fixes**
	- Improved error handling to prevent issues with type mismatches in transaction processes, increasing reliability during token amount validation and preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->