### PR TITLE
Changing fee estimation function

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -169,6 +169,7 @@ export interface IPrepareDepositTxsResponse {
 
 export interface IPrepareXchainRequestFulfillmentTransactionProps {
 	unsignedTxs: IPeanutUnsignedTransaction[]
+	feeEstimation: string
 }
 
 //signAndSubmitTx
@@ -206,6 +207,7 @@ export interface ISquidRoute {
 	value: BigNumber
 	calldata: string
 	to: string
+	estimate?: any
 }
 
 //getCrossChainoptionsForLink

--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -207,7 +207,7 @@ export interface ISquidRoute {
 	value: BigNumber
 	calldata: string
 	to: string
-	estimate?: any
+	txEstimation?: any
 }
 
 //getCrossChainoptionsForLink

--- a/src/index.ts
+++ b/src/index.ts
@@ -2318,7 +2318,7 @@ async function getSquidRoute(args: interfaces.IGetSquidRouteParams): Promise<int
 			value: BigNumber.from(data.route.transactionRequest.value),
 			calldata: data.route.transactionRequest.data,
 			to: data.route.transactionRequest.target,
-			estimate: data.route.estimate,
+			txEstimation: data.route.estimate,
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2318,6 +2318,7 @@ async function getSquidRoute(args: interfaces.IGetSquidRouteParams): Promise<int
 			value: BigNumber.from(data.route.transactionRequest.value),
 			calldata: data.route.transactionRequest.data,
 			to: data.route.transactionRequest.target,
+			estimate: data.route.estimate,
 		}
 	}
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -244,6 +244,20 @@ export async function prepareXchainRequestFulfillmentTransaction({
 		toAddress: recipientAddress,
 		enableBoost: true,
 	})
+
+	let feeEstimation = 0
+	if (routeResult.estimate.feeCosts.length > 0) {
+		routeResult.estimate.feeCosts.forEach((fee) => {
+			feeEstimation += Number(fee.amountUsd)
+		})
+	}
+
+	if (routeResult.estimate.gasCosts.length > 0) {
+		routeResult.estimate.gasCosts.forEach((gas) => {
+			feeEstimation += Number(gas.amountUsd)
+		})
+	}
+
 	if (tokenType == EPeanutLinkType.native) {
 		txOptions = {
 			...txOptions,
@@ -297,31 +311,7 @@ export async function prepareXchainRequestFulfillmentTransaction({
 
 	unsignedTxs.push(unsignedTx)
 
-	return { unsignedTxs }
-}
-
-export function calculateCrossChainTxFee({
-	unsignedTxs,
-	isNativeTxValue,
-	fromAmount,
-}: {
-	unsignedTxs: IPeanutUnsignedTransaction[]
-	isNativeTxValue: boolean
-	fromAmount: string
-}): bigint {
-	let totalFee = BigInt(0)
-
-	for (const tx of unsignedTxs) {
-		if (tx.value) {
-			totalFee += BigInt(tx.value.toString())
-		}
-	}
-
-	if (isNativeTxValue) {
-		totalFee = totalFee - ethers.utils.parseEther(fromAmount).toBigInt()
-	}
-
-	return totalFee
+	return { unsignedTxs, feeEstimation: feeEstimation.toString() }
 }
 
 export function prepareRequestLinkFulfillmentTransaction({

--- a/src/request.ts
+++ b/src/request.ts
@@ -245,15 +245,16 @@ export async function prepareXchainRequestFulfillmentTransaction({
 		enableBoost: true,
 	})
 
+	// Transaction estimation from Squid API allows us to know the transaction fees (gas and fee), then we can iterate over them and add the values ​​that are in dollars
 	let feeEstimation = 0
-	if (routeResult.estimate.feeCosts.length > 0) {
-		routeResult.estimate.feeCosts.forEach((fee) => {
+	if (routeResult.txEstimation.feeCosts.length > 0) {
+		routeResult.txEstimation.feeCosts.forEach((fee) => {
 			feeEstimation += Number(fee.amountUsd)
 		})
 	}
 
-	if (routeResult.estimate.gasCosts.length > 0) {
-		routeResult.estimate.gasCosts.forEach((gas) => {
+	if (routeResult.txEstimation.gasCosts.length > 0) {
+		routeResult.txEstimation.gasCosts.forEach((gas) => {
 			feeEstimation += Number(gas.amountUsd)
 		})
 	}

--- a/src/request.ts
+++ b/src/request.ts
@@ -246,6 +246,12 @@ export async function prepareXchainRequestFulfillmentTransaction({
 	})
 
 	// Transaction estimation from Squid API allows us to know the transaction fees (gas and fee), then we can iterate over them and add the values ​​that are in dollars
+	// Explanation:
+	// feeCosts: Service fees that may be charged by the Squid.
+	// gasCosts: Network gas fees charged for blockchain transactions.
+	// feeEstimation: The total estimated fee, which is the sum of both feeCosts and gasCosts.
+	// Why loops?: Each of these costs can contain multiple items (multiple txs such as approve, swap, etc), so we iterate through each to add their USD values to the total estimated fee.
+
 	let feeEstimation = 0
 	if (routeResult.txEstimation.feeCosts.length > 0) {
 		routeResult.txEstimation.feeCosts.forEach((fee) => {

--- a/test/basic/RequestLinkXChain.test.ts
+++ b/test/basic/RequestLinkXChain.test.ts
@@ -63,13 +63,6 @@ describe('Peanut XChain request links fulfillment tests', function () {
 		})
 		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
 
-		const fee = await peanut.calculateCrossChainTxFee({
-			unsignedTxs: xchainUnsignedTxs.unsignedTxs,
-			isNativeTxValue: false,
-			fromAmount: amountToTestWith.toString(),
-		})
-		console.log('Fee', ethers.utils.formatEther(fee))
-
 		for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
 			const { tx, txHash } = await signAndSubmitTx({
 				unsignedTx,
@@ -143,13 +136,6 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			fromTokenDecimals: 18,
 		})
 		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
-
-		const fee = await peanut.calculateCrossChainTxFee({
-			unsignedTxs: xchainUnsignedTxs.unsignedTxs,
-			isNativeTxValue: true,
-			fromAmount: amountToTestWith.toString(),
-		})
-		console.log('Fee1', ethers.utils.formatEther(fee))
 
 		for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
 			const { tx, txHash } = await signAndSubmitTx({


### PR DESCRIPTION
 **Change in the way network fee is calculated, currently we base on data returned by squid api, i.e. gas cost and fee cost. We add all values ​​from these tables - feeCosts and gasCosts. Based on this data we can estimate network fee.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added fee estimation functionality for cross-chain transaction preparation.
	- Introduced an estimate property in route data for enhanced routing information.

- **Bug Fixes**
	- Removed outdated fee calculation logic from tests, streamlining focus on transaction signing and submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->