### PR TITLE
fix: resolve ens when preparing request xchain

### DIFF
--- a/src/consts/interfaces.consts.ts
+++ b/src/consts/interfaces.consts.ts
@@ -596,6 +596,7 @@ export enum EPrepareCreateTxsStatusCodes {
 	ERROR_SETTING_FEE_OPTIONS,
 	ERROR_ESTIMATING_GAS_LIMIT,
 	ERROR_MAKING_DEPOSIT,
+	ERROR_RESOLVING_ENS_NAME,
 }
 
 export enum ESignAndSubmitTx {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2021,6 +2021,13 @@ async function resolveToENSName({
 	return ensName
 }
 
+async function resolveFromEnsName({ ensName }: { ensName: string }): Promise<string | undefined> {
+	const provider = await getDefaultProvider('1')
+	const x = await provider.resolveName(ensName)
+
+	return x ? x : undefined
+}
+
 /**
  * Claims a link through the Peanut API
  */
@@ -3113,6 +3120,7 @@ const peanut = {
 	trim_decimal_overflow,
 	verifySignature,
 	resolveToENSName,
+	resolveFromEnsName,
 	makeGaslessDepositPayload,
 	prepareApproveERC20Tx,
 	prepareGaslessDepositTx,
@@ -3218,6 +3226,7 @@ export {
 	trim_decimal_overflow,
 	verifySignature,
 	resolveToENSName,
+	resolveFromEnsName,
 	makeGaslessDepositPayload,
 	prepareGaslessDepositTx,
 	makeGaslessReclaimPayload,


### PR DESCRIPTION
A request link can be created for a ens address, in that case we must resolve it when preparing the transaction