### PR TITLE
test: update request tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ export ALCHEMY_API_KEY=""
 export MORALIS_API_KEY=""
 
 # Peanut API key
+export PEANUT_API_URL="https://api.staging.peanut.to"
 export PEANUT_DEV_API_KEY=""
 export ETHERSCAN_API_KEY=""
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -46,6 +46,7 @@ export interface IPrepareXchainRequestFulfillmentTransactionProps {
 	provider: ethers.providers.Provider
 	apiUrl?: string
 	tokenType: EPeanutLinkType
+	APIKey?: string
 }
 
 export interface ISubmitRequestLinkFulfillmentProps {
@@ -177,8 +178,9 @@ export async function prepareXchainRequestFulfillmentTransaction({
 	provider,
 	apiUrl = 'https://api.peanut.to/',
 	tokenType,
+	APIKey,
 }: IPrepareXchainRequestFulfillmentTransactionProps): Promise<interfaces.IPrepareXchainRequestFulfillmentTransactionProps> {
-	const linkDetails = await getRequestLinkDetails({ link: link, apiUrl: apiUrl })
+	const linkDetails = await getRequestLinkDetails({ link, apiUrl, APIKey })
 	let { tokenAddress: destinationToken } = linkDetails
 	let {
 		chainId: destinationChainId,

--- a/test/basic/RequestLinkXChain.test.ts
+++ b/test/basic/RequestLinkXChain.test.ts
@@ -7,30 +7,25 @@ import { EPeanutLinkType } from '../../src/consts/interfaces.consts'
 dotenv.config()
 
 describe('Peanut XChain request links fulfillment tests', function () {
-	it('Create a request link and fulfill it cross-chain', async function () {
+	it('USDC on Optimism to USDT on Polygon', async function () {
 		peanut.toggleVerbose(true)
-		const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
-		// const relayerPrivateKey = process.env.TEST_WALLET_X_CHAIN_RELAYER!
+		const userPrivateKey = process.env.TEST_WALLET_PRIVATE_KEY!
 
 		// Parameters that affect the test behaviour
 		const sourceChainId = '10' // Optimism
 		const destinationChainId = '137' // Polygon
 		const amountToTestWith = 0.1
 		const tokenDecimals = 6
+		const apiUrl = process.env.PEANUT_API_URL!
 		const APIKey = process.env.PEANUT_DEV_API_KEY!
 		const sourceChainProvider = await getDefaultProvider(sourceChainId)
 		console.log('Source chain provider', sourceChainProvider)
 
 		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
 
-		const recipientAddress = '0x42A5DC31169Da17639468e7Ffa271e90Fdb5e85A'
+		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
 		const tokenAddress = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' // USDC on Optimism
 		const destinationToken = '0xc2132D05D31c914a87C6611C10748AEb04B58e8F' // USDT on Polygon
-		const initialBalance = await peanut.getTokenBalance({
-			tokenAddress: destinationToken,
-			walletAddress: recipientAddress,
-			chainId: destinationChainId,
-		})
 		const { link } = await peanut.createRequestLink({
 			chainId: destinationChainId,
 			tokenAddress: destinationToken,
@@ -39,14 +34,14 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			tokenDecimals: tokenDecimals.toString(),
 			recipientAddress,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/withFormData',
+			apiUrl,
 		})
 		console.log('Created a request link on the source chain!', link)
 
 		const linkDetails = await peanut.getRequestLinkDetails({
 			link,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
+			apiUrl,
 		})
 		console.log('Got the link details!', linkDetails)
 
@@ -57,9 +52,10 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			link,
 			squidRouterUrl: getSquidRouterUrl(true, false),
 			provider: sourceChainProvider,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
 			fromTokenDecimals: 6,
 			tokenType: EPeanutLinkType.erc20,
+			apiUrl,
+			APIKey,
 		})
 		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
 
@@ -86,7 +82,7 @@ describe('Peanut XChain request links fulfillment tests', function () {
 		// expect(finalBalance).toBe((Number(initialBalance) + amountToTestWith).toString())
 	}, 120000)
 
-	it('Create a request link and fulfill it cross-chain native token', async function () {
+	it('ETH on Optimism to ETH on Arbitrum', async function () {
 		peanut.toggleVerbose(true)
 		const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
 
@@ -95,13 +91,14 @@ describe('Peanut XChain request links fulfillment tests', function () {
 		const destinationChainId = '42161' // Arbitrum
 		const amountToTestWith = 0.0001
 		const tokenDecimals = '18'
+		const apiUrl = process.env.PEANUT_API_URL!
 		const APIKey = process.env.PEANUT_DEV_API_KEY!
 		const sourceChainProvider = await getDefaultProvider(sourceChainId)
 		console.log('Source chain provider', sourceChainProvider)
 
 		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
 
-		const recipientAddress = '0x42A5DC31169Da17639468e7Ffa271e90Fdb5e85A'
+		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
 		const tokenAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' // ETH on Optimism
 		const destinationToken = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' // ETH on Arbitrum
 
@@ -113,14 +110,14 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			tokenDecimals,
 			recipientAddress,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/withFormData',
+			apiUrl,
 		})
 		console.log('Created a request link on the source chain!', link)
 
 		const linkDetails = await peanut.getRequestLinkDetails({
 			link,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
+			apiUrl,
 		})
 		console.log('Got the link details!', linkDetails)
 
@@ -131,9 +128,10 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			link,
 			squidRouterUrl: getSquidRouterUrl(true, false),
 			provider: sourceChainProvider,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
 			tokenType: EPeanutLinkType.native,
 			fromTokenDecimals: 18,
+			apiUrl,
+			APIKey,
 		})
 		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
 
@@ -152,23 +150,23 @@ describe('Peanut XChain request links fulfillment tests', function () {
 		}
 	}, 120000)
 
-	it('Create a request link and fulfill it cross-chain native token', async function () {
+	it('ETH on Optimism to USDC on Optimism', async function () {
 		peanut.toggleVerbose(true)
 		const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
-		// const relayerPrivateKey = process.env.TEST_WALLET_X_CHAIN_RELAYER!
 
 		// Parameters that affect the test behaviour
 		const sourceChainId = '10' // Arbitrum
 		const destinationChainId = '10' // Optimism
 		const amountToTestWith = 0.1
 		// const tokenDecimals = '18'
+		const apiUrl = process.env.PEANUT_API_URL!
 		const APIKey = process.env.PEANUT_DEV_API_KEY!
 		const sourceChainProvider = await getDefaultProvider(sourceChainId)
 		console.log('Source chain provider', sourceChainProvider)
 
 		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
 
-		const recipientAddress = '0x42A5DC31169Da17639468e7Ffa271e90Fdb5e85A'
+		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
 		const tokenAddress = '0x0000000000000000000000000000000000000000' // ETH on Optimism
 		const destinationToken = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' // USDC on Optimism
 
@@ -180,14 +178,14 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			tokenDecimals: '6',
 			recipientAddress,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/withFormData',
+			apiUrl,
 		})
 		console.log('Created a request link on the source chain!', link)
 
 		const linkDetails = await peanut.getRequestLinkDetails({
 			link,
 			APIKey,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
+			apiUrl,
 		})
 		console.log('Got the link details!', linkDetails)
 
@@ -198,9 +196,10 @@ describe('Peanut XChain request links fulfillment tests', function () {
 			link,
 			squidRouterUrl: getSquidRouterUrl(true, false),
 			provider: sourceChainProvider,
-			apiUrl: 'https://staging.peanut.to/api/proxy/get',
 			tokenType: EPeanutLinkType.native,
 			fromTokenDecimals: 18,
+			apiUrl,
+			APIKey,
 		})
 		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
 

--- a/test/basic/RequestLinkXChain.test.ts
+++ b/test/basic/RequestLinkXChain.test.ts
@@ -7,72 +7,122 @@ import { EPeanutLinkType } from '../../src/consts/interfaces.consts'
 dotenv.config()
 
 describe('Peanut XChain request links fulfillment tests', function () {
-	it('USDC on Optimism to USDT on Polygon', async function () {
-		peanut.toggleVerbose(true)
-		const userPrivateKey = process.env.TEST_WALLET_PRIVATE_KEY!
+	it.each([
+		{
+			amount: '0.1',
+			sourceToken: {
+				chain: '10',
+				address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85', // USDC on Optimism
+				decimals: 6,
+				name: 'USDC on Optimism',
+				type: EPeanutLinkType.erc20,
+			},
+			destinationToken: {
+				chain: '137',
+				address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F', // USDT on Polygon
+				decimals: 6,
+				name: 'USDT on Polygon',
+				type: EPeanutLinkType.erc20,
+			},
+		},
+		{
+			amount: '0.0001',
+			sourceToken: {
+				chain: '10',
+				address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // ETH on Optimism
+				decimals: 18,
+				name: 'ETH on Optimism',
+				type: EPeanutLinkType.native,
+			},
+			destinationToken: {
+				chain: '42161',
+				address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // ETH on Arbitrum
+				decimals: 18,
+				name: 'ETH on Arbitrum',
+				type: EPeanutLinkType.native,
+			},
+		},
+		{
+			amount: '0.1',
+			sourceToken: {
+				chain: '10',
+				address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // ETH on Optimism
+				decimals: 18,
+				name: 'ETH on Optimism',
+				type: EPeanutLinkType.native,
+			},
+			destinationToken: {
+				chain: '10',
+				address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85', // USDC on Optimism
+				decimals: 6,
+				name: 'USDC on Optimism',
+				type: EPeanutLinkType.erc20,
+			},
+		},
+	])(
+		'$sourceToken.name to $destinationToken.name',
+		async ({ amount, sourceToken, destinationToken }) => {
+			peanut.toggleVerbose(true)
+			const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
 
-		// Parameters that affect the test behaviour
-		const sourceChainId = '10' // Optimism
-		const destinationChainId = '137' // Polygon
-		const amountToTestWith = 0.1
-		const tokenDecimals = 6
-		const apiUrl = process.env.PEANUT_API_URL!
-		const APIKey = process.env.PEANUT_DEV_API_KEY!
-		const sourceChainProvider = await getDefaultProvider(sourceChainId)
-		console.log('Source chain provider', sourceChainProvider)
+			// Parameters that affect the test behaviour
+			const apiUrl = process.env.PEANUT_API_URL!
+			const APIKey = process.env.PEANUT_DEV_API_KEY!
+			const sourceChainProvider = await getDefaultProvider(sourceToken.chain)
+			console.log('Source chain provider', sourceChainProvider)
 
-		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
+			const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
 
-		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
-		const tokenAddress = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' // USDC on Optimism
-		const destinationToken = '0xc2132D05D31c914a87C6611C10748AEb04B58e8F' // USDT on Polygon
-		const { link } = await peanut.createRequestLink({
-			chainId: destinationChainId,
-			tokenAddress: destinationToken,
-			tokenAmount: amountToTestWith.toString(),
-			tokenType: EPeanutLinkType.erc20,
-			tokenDecimals: tokenDecimals.toString(),
-			recipientAddress,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Created a request link on the source chain!', link)
+			const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
 
-		const linkDetails = await peanut.getRequestLinkDetails({
-			link,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Got the link details!', linkDetails)
-
-		const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
-			fromChainId: sourceChainId,
-			senderAddress: userSourceChainWallet.address,
-			fromToken: tokenAddress,
-			link,
-			squidRouterUrl: getSquidRouterUrl(true, false),
-			provider: sourceChainProvider,
-			fromTokenDecimals: 6,
-			tokenType: EPeanutLinkType.erc20,
-			apiUrl,
-			APIKey,
-		})
-		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
-
-		for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
-			const { tx, txHash } = await signAndSubmitTx({
-				unsignedTx,
-				structSigner: {
-					signer: userSourceChainWallet,
-					gasLimit: BigNumber.from(2_000_000),
-				},
+			const { link } = await peanut.createRequestLink({
+				chainId: destinationToken.chain,
+				tokenAddress: destinationToken.address,
+				tokenAmount: amount,
+				tokenType: destinationToken.type,
+				tokenDecimals: destinationToken.decimals.toString(),
+				recipientAddress,
+				APIKey,
+				apiUrl,
 			})
+			console.log('Created a request link on the source chain!', link)
 
-			console.log('Submitted a transaction to fulfill the request link with tx hash', txHash)
-			await tx.wait()
-			console.log('Request link fulfillment initiated!')
-		}
+			const linkDetails = await peanut.getRequestLinkDetails({
+				link,
+				APIKey,
+				apiUrl,
+			})
+			console.log('Got the link details!', linkDetails)
 
+			const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
+				fromChainId: sourceToken.chain,
+				senderAddress: userSourceChainWallet.address,
+				fromToken: sourceToken.address,
+				link,
+				squidRouterUrl: getSquidRouterUrl(true, false),
+				provider: sourceChainProvider,
+				tokenType: sourceToken.type,
+				fromTokenDecimals: sourceToken.decimals,
+				apiUrl,
+				APIKey,
+			})
+			console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
+
+			for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
+				const { tx, txHash } = await signAndSubmitTx({
+					unsignedTx,
+					structSigner: {
+						signer: userSourceChainWallet,
+						gasLimit: BigNumber.from(2_000_000),
+					},
+				})
+
+				console.log('Submitted a transaction to fulfill the request link with tx hash', txHash)
+				await tx.wait()
+				console.log('Request link fulfillment initiated!')
+			}
+			// TODO: expect something here
+			/*
 		const finalBalance = await peanut.getTokenBalance({
 			tokenAddress: destinationToken,
 			walletAddress: recipientAddress,
@@ -80,141 +130,8 @@ describe('Peanut XChain request links fulfillment tests', function () {
 		})
 		console.log('Final balance of recipient:', finalBalance)
 		// expect(finalBalance).toBe((Number(initialBalance) + amountToTestWith).toString())
-	}, 120000)
-
-	it('ETH on Optimism to ETH on Arbitrum', async function () {
-		peanut.toggleVerbose(true)
-		const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
-
-		// Parameters that affect the test behaviour
-		const sourceChainId = '10' // Optimism
-		const destinationChainId = '42161' // Arbitrum
-		const amountToTestWith = 0.0001
-		const tokenDecimals = '18'
-		const apiUrl = process.env.PEANUT_API_URL!
-		const APIKey = process.env.PEANUT_DEV_API_KEY!
-		const sourceChainProvider = await getDefaultProvider(sourceChainId)
-		console.log('Source chain provider', sourceChainProvider)
-
-		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
-
-		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
-		const tokenAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' // ETH on Optimism
-		const destinationToken = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' // ETH on Arbitrum
-
-		const { link } = await peanut.createRequestLink({
-			chainId: destinationChainId,
-			tokenAddress: destinationToken,
-			tokenAmount: amountToTestWith.toString(),
-			tokenType: EPeanutLinkType.native,
-			tokenDecimals,
-			recipientAddress,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Created a request link on the source chain!', link)
-
-		const linkDetails = await peanut.getRequestLinkDetails({
-			link,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Got the link details!', linkDetails)
-
-		const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
-			fromChainId: sourceChainId,
-			senderAddress: userSourceChainWallet.address,
-			fromToken: tokenAddress,
-			link,
-			squidRouterUrl: getSquidRouterUrl(true, false),
-			provider: sourceChainProvider,
-			tokenType: EPeanutLinkType.native,
-			fromTokenDecimals: 18,
-			apiUrl,
-			APIKey,
-		})
-		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
-
-		for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
-			const { tx, txHash } = await signAndSubmitTx({
-				unsignedTx,
-				structSigner: {
-					signer: userSourceChainWallet,
-					gasLimit: BigNumber.from(2_000_000),
-				},
-			})
-
-			console.log('Submitted a transaction to fulfill the request link with tx hash', txHash)
-			await tx.wait()
-			console.log('Request link fulfillment initiated!')
-		}
-	}, 120000)
-
-	it('ETH on Optimism to USDC on Optimism', async function () {
-		peanut.toggleVerbose(true)
-		const userPrivateKey = process.env.TEST_WALLET_X_CHAIN_USER!
-
-		// Parameters that affect the test behaviour
-		const sourceChainId = '10' // Arbitrum
-		const destinationChainId = '10' // Optimism
-		const amountToTestWith = 0.1
-		// const tokenDecimals = '18'
-		const apiUrl = process.env.PEANUT_API_URL!
-		const APIKey = process.env.PEANUT_DEV_API_KEY!
-		const sourceChainProvider = await getDefaultProvider(sourceChainId)
-		console.log('Source chain provider', sourceChainProvider)
-
-		const userSourceChainWallet = new ethers.Wallet(userPrivateKey, sourceChainProvider)
-
-		const recipientAddress = new ethers.Wallet(process.env.TEST_WALLET_PRIVATE_KEY2!).address
-		const tokenAddress = '0x0000000000000000000000000000000000000000' // ETH on Optimism
-		const destinationToken = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' // USDC on Optimism
-
-		const { link } = await peanut.createRequestLink({
-			chainId: destinationChainId,
-			tokenAddress: destinationToken,
-			tokenAmount: amountToTestWith.toString(),
-			tokenType: EPeanutLinkType.erc20,
-			tokenDecimals: '6',
-			recipientAddress,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Created a request link on the source chain!', link)
-
-		const linkDetails = await peanut.getRequestLinkDetails({
-			link,
-			APIKey,
-			apiUrl,
-		})
-		console.log('Got the link details!', linkDetails)
-
-		const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
-			fromChainId: sourceChainId,
-			senderAddress: userSourceChainWallet.address,
-			fromToken: tokenAddress,
-			link,
-			squidRouterUrl: getSquidRouterUrl(true, false),
-			provider: sourceChainProvider,
-			tokenType: EPeanutLinkType.native,
-			fromTokenDecimals: 18,
-			apiUrl,
-			APIKey,
-		})
-		console.log('Computed x chain unsigned fulfillment transactions', xchainUnsignedTxs)
-
-		for (const unsignedTx of xchainUnsignedTxs.unsignedTxs) {
-			const { tx, txHash } = await signAndSubmitTx({
-				unsignedTx,
-				structSigner: {
-					signer: userSourceChainWallet,
-					gasLimit: BigNumber.from(2_000_000),
-				},
-			})
-
-			console.log('Submitted a transaction to fulfill the request link with tx hash', txHash)
-			await tx.wait()
-			console.log('Request link fulfillment initiated!')
-		}
-	}, 120000)
+    */
+		},
+		120000
+	)
 })


### PR DESCRIPTION
## Code changes
- prepareXchainRequestFulfillmentTransaction now accepts and uses api key

## Test changes
- Use back api instead of front
- Actually check that balance changed
- Refactor to remove duplication of code between tests (all tests were the same but with different pairs)