### PR TITLE
feat(request): accept uuid directly on getRequestLinkDetails

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -22,11 +22,17 @@ export interface ICreateRequestLinkProps {
 	APIKey?: string
 }
 
-export interface IGetRequestLinkDetailsProps {
-	link: string
+export type IGetRequestLinkDetailsProps = {
 	APIKey?: string
 	apiUrl?: string
-}
+} & (
+	| {
+			link: string
+	  }
+	| {
+			uuid: string
+	  }
+)
 
 export interface IPrepareRequestLinkFulfillmentTransactionProps {
 	recipientAddress: string
@@ -154,12 +160,12 @@ export async function createRequestLink({
 	}
 }
 
-export async function getRequestLinkDetails({
-	link,
-	APIKey,
-	apiUrl = 'https://api.peanut.to/',
-}: IGetRequestLinkDetailsProps): Promise<IGetRequestLinkDetailsResponse> {
-	const uuid = getUuidFromLink(link)
+export async function getRequestLinkDetails(
+	props: IGetRequestLinkDetailsProps
+): Promise<IGetRequestLinkDetailsResponse> {
+	const { APIKey, apiUrl = 'https://api.peanut.to/' } = props
+
+	const uuid = 'uuid' in props ? props.uuid : getUuidFromLink(props.link)
 
 	const apiResponse = await fetch(normalizePath(`${apiUrl}/request-links/${uuid}`), {
 		method: 'GET',

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -60,6 +60,20 @@ describe('Request', () => {
 
 			expect(mockFetch).toHaveBeenCalledWith(`https://api.peanut.to/request-links/${linkUuid}`, expect.anything())
 		})
+
+		it('should accept uuid directly', async () => {
+			const linkUuid = 'ee3b904d-9809-4b97-b82b-34de1d1a7314'
+			mockFetch.mockResolvedValueOnce({
+				json: jest.fn().mockResolvedValueOnce({
+					link: `https://peanut.to/request/pay?id=${linkUuid}`,
+				}),
+				status: 200,
+			})
+
+			await getRequestLinkDetails({ uuid: linkUuid })
+
+			expect(mockFetch).toHaveBeenCalledWith(`https://api.peanut.to/request-links/${linkUuid}`, expect.anything())
+		})
 	})
 
 	describe('submitRequestLinkFulfillment', () => {


### PR DESCRIPTION
Fetch request details either by link or by uuid

https://github.com/peanutprotocol/peanut-ui/pull/469 depends on this