### PR TITLE
fix: don't send double amount for native xchain requests

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -244,6 +244,7 @@ export async function prepareXchainRequestFulfillmentTransaction(
 		fromToken: fromTokenData,
 		toAmount: destinationTokenAmount,
 		toToken: toTokenData,
+		slippagePercentage: 0.3, // this can be low because squid will add slippage
 	})
 
 	console.log('estimatedFromAmount', estimatedFromAmount)
@@ -276,13 +277,13 @@ export async function prepareXchainRequestFulfillmentTransaction(
 
 	let feeEstimation = 0
 	if (routeResult.txEstimation.feeCosts.length > 0) {
-		routeResult.txEstimation.feeCosts.forEach((fee) => {
+		routeResult.txEstimation.feeCosts.forEach((fee: { amountUsd: string }) => {
 			feeEstimation += Number(fee.amountUsd)
 		})
 	}
 
 	if (routeResult.txEstimation.gasCosts.length > 0) {
-		routeResult.txEstimation.gasCosts.forEach((gas) => {
+		routeResult.txEstimation.gasCosts.forEach((gas: { amountUsd: string }) => {
 			feeEstimation += Number(gas.amountUsd)
 		})
 	}
@@ -290,7 +291,6 @@ export async function prepareXchainRequestFulfillmentTransaction(
 	if (tokenType == EPeanutLinkType.native) {
 		txOptions = {
 			...txOptions,
-			value: tokenAmount,
 		}
 	} else if (tokenType == EPeanutLinkType.erc20) {
 		config.verbose && console.log('checking allowance...')
@@ -322,23 +322,11 @@ export async function prepareXchainRequestFulfillmentTransaction(
 
 	config.verbose && console.log('Squid route calculated :)', { routeResult })
 
-	let unsignedTx: IPeanutUnsignedTransaction = {}
-
-	if (tokenType == EPeanutLinkType.native) {
-		unsignedTx = {
-			data: routeResult.calldata,
-			to: routeResult.to,
-			value: BigInt(routeResult.value.toString()) + BigInt(txOptions.value.toString()),
-		}
-	} else if (tokenType == EPeanutLinkType.erc20) {
-		unsignedTx = {
-			data: routeResult.calldata,
-			to: routeResult.to,
-			value: BigInt(routeResult.value.toString()),
-		}
-	}
-
-	unsignedTxs.push(unsignedTx)
+	unsignedTxs.push({
+		data: routeResult.calldata,
+		to: routeResult.to,
+		value: BigInt(routeResult.value.toString()),
+	})
 
 	return { unsignedTxs, feeEstimation: feeEstimation.toString(), estimatedFromAmount }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -703,7 +703,7 @@ export async function prepareXchainFromAmountCalculation({
 	fromToken,
 	toAmount,
 	toToken,
-	slippagePercentage = 1.5,
+	slippagePercentage = 0.3, // 0.3%
 }: {
 	fromToken: TokenData
 	toToken: TokenData
@@ -736,17 +736,12 @@ export async function prepareXchainFromAmountCalculation({
 		const toTokenPriceBN = ethers.utils.parseUnits(toTokenPrice.toString(), normalizedDecimalCount)
 		const toAmountBN = ethers.utils.parseUnits(toAmount, normalizedDecimalCount)
 		const fromAmountBN = toTokenPriceBN.mul(toAmountBN).div(fromTokenPriceBN)
-
 		// Slippage percentage is multiplied by 1000 to convert it into an integer form that represents the fraction.
 		// because BigNumber cannot handle floating points directly.
+		// TODO: use bigint
 		const slippageFractionBN = ethers.BigNumber.from(Math.floor(slippagePercentage * 1000))
-
-		// For example, a 10.5% slippage is represented here as 10,500 (after scaling),
-		// and dividing by 100,000 effectively applies the 10.5% to the fromAmountBN.
-		const slippageBN = fromAmountBN.mul(slippageFractionBN).div(100000)
-
+		const slippageBN = fromAmountBN.mul(slippageFractionBN).div(100000) // 1000 * 100 (10e5)
 		const totalFromAmountBN = fromAmountBN.add(slippageBN)
-
 		return ethers.utils.formatUnits(totalFromAmountBN, fromToken.decimals)
 	} catch (error) {
 		console.error('Failed to calculate fromAmount:', error)


### PR DESCRIPTION
When paying a request cross chain from a native token, the amount of the transaction was ~2x the amount. This commit fixes that and also sets a lower slippage on our side. (We send with slippage and then squid tries to honor that with its own slippage, so we can set it low here, did some tests with even lower values and the requestor always received more than the requested amount)

Tested locally with peanut-ui, will be pulled in https://github.com/peanutprotocol/peanut-ui/pull/494